### PR TITLE
Removing the Storage plugin from the list

### DIFF
--- a/cluster/juju/layers/kubernetes/templates/master.json
+++ b/cluster/juju/layers/kubernetes/templates/master.json
@@ -38,7 +38,7 @@
               "--etcd-certfile={{ etcd_cert }}",
               {%- endif %}
               "--etcd-servers={{ connection_string }}",
-              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,DefaultStorageClass,ResourceQuota",
+              "--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota",
               "--client-ca-file=/srv/kubernetes/ca.crt",
               "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
               "--min-request-timeout=300",


### PR DESCRIPTION
The Juju cluster fails to bring up the apiserver. Using the docker logs I see the API server complaining about a fatal error.
```
F0830 17:04:16.922997       1 plugins.go:143] Unknown admission plugin: DefaultStorageClass
```

**Which issue this PR fixes** : fixes #31726