### PR TITLE
Automated testing shouldn't bootstrap

### DIFF
--- a/cluster/juju/layers/kubernetes/tests/tests.yaml
+++ b/cluster/juju/layers/kubernetes/tests/tests.yaml
@@ -1,1 +1,2 @@
 tests: "*kubernetes*"
+bootstrap: false


### PR DESCRIPTION
Juju bootstrapping is an act of cost. This should be an explicit action
by the tooling surrounding bundle-tester when testing a charm. Setting
bootstrap:false will allow us to get faster feedback at lower cost when
running the kubernetes charm under ci.