### PR TITLE
Automated testing shouldn't bootstrap

### DIFF
--- a/cluster/juju/layers/kubernetes/tests/tests.yaml
+++ b/cluster/juju/layers/kubernetes/tests/tests.yaml
@@ -1,1 +1,5 @@
 tests: "*kubernetes*"
+bootstrap: false
+reset: false
+python_packages:
+  - tox


### PR DESCRIPTION
Juju bootstrapping is an act of cost. This should be an explicit action
by the tooling surrounding bundle-tester when testing a charm. Setting
bootstrap:false will allow us to get faster feedback at lower cost when
running the kubernetes charm under ci. Additionally doesn't reset so
no communication attempt is made to the controller

Additionally add tox to test dependency list