### PR TITLE
Fixes messaging on the master unit

### DIFF
--- a/cluster/juju/layers/kubernetes/reactive/k8s.py
+++ b/cluster/juju/layers/kubernetes/reactive/k8s.py
@@ -307,7 +307,7 @@ def start_cadvisor():
 
 
 @when('kubelet.available', 'kubeconfig.created')
-@when_any('proxy.available', 'cadvisor.available', 'skydns.available')
+@when_any('proxy.available', 'cadvisor.available', 'kubedns.available')
 def final_message():
     '''Issue some final messages when the services are started. '''
     # TODO: Run a simple/quick health checks before issuing this message.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Corrects the locked messaging on the master unit



**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
None
```

Removes a stale state, and now reacts when kubedns is available as it
should.