### PR TITLE
Adds --require-kubeconfig flag to kubelet

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -202,6 +202,8 @@ def render_init_scripts(kube_api):
 
     # Create a flag manager for kubelet to render kubelet_opts.
     kubelet_opts = FlagManager('kubelet')
+    # Declare to kubelet it needs to read from kubeconfig
+    kubelet_opts.add('--require-kubeconfig', None)
     kubelet_opts.add('--kubeconfig', '/srv/kubernetes/config')
     context['kubelet_opts'] = kubelet_opts.to_s()
     # Create a flag manager for kube-proxy to render kube_proxy_opts.


### PR DESCRIPTION
This directive tells kubelet how to contact the master apiserver node(s)
    during cluster turn up. This is required when not using the deprecated
    --apiservers flag to the kubelet binary