### PR TITLE
DNS options were being added without flags

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -139,8 +139,8 @@ def render_dns_scripts(kube_api, ca, client, kube_dns):
     # Initialize a FlagManager object to add flags to unit data.
     opts = FlagManager('kubelet')
     # Append the DNS flags + data to the FlagManager object.
-    opts.add('cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
-    opts.add('cluster-domain', dns['domain'])
+    opts.add('--cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
+    opts.add('--cluster-domain', dns['domain'])
     create_config(kube_api)
     render_init_scripts(kube_api)
     restart_unit_services()


### PR DESCRIPTION
This will cause errors during cluster turnup without having the --'s,
    they get rendered in teh manifest without their flags and instead are
    interpreted as arguments to other flags.