### PR TITLE
Remove worker caching states and re-work the user messaging

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -42,23 +42,23 @@ def install():
     try:
         archive = hookenv.resource_get('kubernetes')
     except Exception:
-        message = 'Error fetching the kubernetes resource'
+        message = 'Error fetching the kubernetes resource.'
         hookenv.log(message)
         hookenv.status_set('blocked', message)
         return
 
     if not archive:
-        hookenv.log('Missing kubernetes resource')
-        hookenv.status_set('blocked', 'Missing kubernetes resource')
+        hookenv.log('Missing kubernetes resource.')
+        hookenv.status_set('blocked', 'Missing kubernetes resource.')
         return
 
     # Handle null resource publication, we check if filesize < 1mb
     filesize = os.stat(archive).st_size
     if filesize < 1000000:
-        hookenv.status_set('blocked', 'Incomplete kubernetes resource')
+        hookenv.status_set('blocked', 'Incomplete kubernetes resource.')
         return
 
-    hookenv.status_set('maintenance', 'Unpacking Kubernetes.')
+    hookenv.status_set('maintenance', 'Unpacking kubernetes resource.')
     files_dir = os.path.join(hookenv.charm_dir(), 'files')
 
     os.makedirs(files_dir, exist_ok=True)
@@ -124,7 +124,7 @@ def set_app_version():
       'kube_master_components.installed')
 def ready_messaging():
     ''' Signal at the end of the run that we are running. '''
-    hookenv.status_set('active', "Kubernetes master running.")
+    hookenv.status_set('active', 'Kubernetes master running.')
 
 
 @when('etcd.available', 'kube_master_components.installed',
@@ -205,7 +205,7 @@ def push_api_data(kube_api):
 def gather_sdn_data(sdn_plugin):
     sdn_data = sdn_plugin.get_sdn_config()
     if not sdn_data['cidr'] or not sdn_data['subnet'] or not sdn_data['mtu']:
-        hookenv.status_set('waiting', 'Waiting on SDN configuration')
+        hookenv.status_set('waiting', 'Waiting on SDN configuration.')
         return
     api_opts = FlagManager('kube-apiserver')
     api_opts.add('--service-cluster-ip-range', sdn_data['cidr'])
@@ -335,11 +335,6 @@ def arch():
     architecture = check_output(['dpkg', '--print-architecture']).rstrip()
     # Convert the binary result into a string.
     architecture = architecture.decode('utf-8')
-    # Validate the architecture is supported by kubernetes.
-    if architecture not in ['amd64', 'arm', 'arm64', 'ppc64le']:
-        message = 'Unsupported machine architecture: {0}'.format(architecture)
-        hookenv.status_set('blocked', message)
-        raise Exception(message)
     return architecture
 
 

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -12,7 +12,6 @@ from charms.reactive import remove_state
 from charms.reactive import set_state
 from charms.reactive import when
 from charms.reactive import when_not
-from charms.reactive.helpers import data_changed
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import host
@@ -100,6 +99,44 @@ def set_app_version():
     hookenv.application_version_set(version.split(b' v')[-1].rstrip())
 
 
+@when('kubernetes.worker.bins.installed')
+@when_not('kube-dns.available')
+def notify_user_transient_status():
+    ''' Notify to the user we are in a transient state and the application
+    is still converging. Potentially remotely, or we may be in a detached loop
+    wait state '''
+
+    # During deployment the worker has to start kubelet without cluster dns
+    # configured. If this is the first unit online in a service pool waiting
+    # to self host the dns pod, and configure itself to query the dns service
+    # declared in the kube-system namespace
+
+    hookenv.status_set('waiting',
+                       'Waiting for cluster-manager to initiate start')
+
+
+@when('kubernetes.worker.bins.installed', 'kube-dns.available')
+def notify_user_converging_status(kube_dns):
+    ''' There are different states that the worker can be in, where we are
+    waiting for dns, waiting for cluster turnup, or ready to serve
+    applications'''
+    # Daemon options are managed by the FlagManager class
+    kubelet_opts = FlagManager('kubelet')
+
+    # Query the FlagManager dict for the dns option, and determine if
+    # kubelet is running
+    if (_systemctl_is_active('kubelet') and
+       '--cluster-dns' not in kubelet_opts.data):
+        hookenv.status_set('waiting', 'Waiting on cluster dns')
+    elif(_systemctl_is_active('kubelet') and
+         '--cluster-dns' in kubelet_opts.data):
+        hookenv.status_set('active',
+                           'Kubernetes worker running')
+    # if kubelet is not running, we're waiting on something else to converge
+    elif(not _systemctl_is_active('kubelet')):
+        hookenv.status_set('waiting', 'waiting on kubelet')
+
+
 @when('sdn-plugin.available', 'docker.available')
 @when_not('sdn.configured')
 def container_sdn_setup(sdn):
@@ -119,8 +156,10 @@ def container_sdn_setup(sdn):
 
 
 @when('kubernetes.worker.bins.installed', 'kube-api-endpoint.available',
-      'certificates.ca.available', 'certificates.client.cert.available')
-def render_scripts(kube_api, ca, client):
+      'tls_client.ca.saved', 'tls_client.client.certificate.saved',
+      'tls_client.client.key.saved')
+@when_not('kube-dns.available')
+def start_worker(kube_api):
     '''We have related to either an api server or a load balancer connected
     to the apiserver along with the certificate and keys. Render the init
     scripts.'''
@@ -130,9 +169,9 @@ def render_scripts(kube_api, ca, client):
 
 
 @when('kubernetes.worker.bins.installed', 'kube-api-endpoint.available',
-      'certificates.ca.available', 'certificates.client.cert.available',
-      'kube-dns.available')
-def render_dns_scripts(kube_api, ca, client, kube_dns):
+      'tls_client.ca.saved', 'tls_client.client.certificate.saved',
+      'tls_client.client.key.saved', 'kube-dns.available')
+def render_dns_scripts(kube_api, kube_dns):
     ''' The dns is now available, re-render init config with DNS data. '''
     # Fetch the DNS data on the relationship.
     dns = kube_dns.details()
@@ -141,6 +180,7 @@ def render_dns_scripts(kube_api, ca, client, kube_dns):
     # Append the DNS flags + data to the FlagManager object.
     opts.add('--cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
     opts.add('--cluster-domain', dns['domain'])
+
     create_config(kube_api)
     render_init_scripts(kube_api)
     restart_unit_services()
@@ -153,29 +193,21 @@ def create_config(kube_api):
     layer_options = layer.options('tls-client')
     # Get all the paths to the tls information required for kubeconfig.
     ca = layer_options.get('ca_certificate_path')
-    ca_exists = ca and os.path.isfile(ca)
     key = layer_options.get('client_key_path')
-    key_exists = key and os.path.isfile(key)
     cert = layer_options.get('client_certificate_path')
-    cert_exists = cert and os.path.isfile(cert)
-    # Do we have everything we need?
-    if ca_exists and key_exists and cert_exists:
-        # Cache last server string to know if we need to regenerate the config.
-        if not data_changed('kubeconfig.server', server):
-            return
 
-        # Create kubernetes configuration in the default location for ubuntu.
-        create_kubeconfig('/home/ubuntu/.kube/config', server, ca, key, cert,
-                          user='ubuntu')
-        # Make the config file readable by the ubuntu users so juju scp works.
-        cmd = ['chown', 'ubuntu:ubuntu', '/home/ubuntu/.kube/config']
-        check_call(cmd)
-        # Create kubernetes configuration in the default location for root.
-        create_kubeconfig('/root/.kube/config', server, ca, key, cert,
-                          user='root')
-        # Create kubernetes configuration for kubelet, and kube-proxy services.
-        create_kubeconfig('/srv/kubernetes/config', server, ca, key, cert,
-                          user='kubelet')
+    # Create kubernetes configuration in the default location for ubuntu.
+    create_kubeconfig('/home/ubuntu/.kube/config', server, ca, key, cert,
+                      user='ubuntu')
+    # Make the config file readable by the ubuntu users so juju scp works.
+    cmd = ['chown', 'ubuntu:ubuntu', '/home/ubuntu/.kube/config']
+    check_call(cmd)
+    # Create kubernetes configuration in the default location for root.
+    create_kubeconfig('/root/.kube/config', server, ca, key, cert,
+                      user='root')
+    # Create kubernetes configuration for kubelet, and kube-proxy services.
+    create_kubeconfig('/srv/kubernetes/config', server, ca, key, cert,
+                      user='kubelet')
 
 
 def render_init_scripts(kube_api):
@@ -258,7 +290,6 @@ def restart_unit_services():
     hookenv.log('Restarting kubelet, and kube-proxy.')
     call(['systemctl', 'restart', 'kubelet'])
     call(['systemctl', 'restart', 'kube-proxy'])
-    hookenv.status_set('active', 'Worker ready')
 
 
 def get_kube_api_server(kube_api):
@@ -279,3 +310,13 @@ def get_kube_api_server(kube_api):
     else:
         hookenv.log('Unable to get "server" not services.')
     return server
+
+
+def _systemctl_is_active(application):
+    ''' Poll systemctl to determine if the application is running '''
+    cmd = ['systemctl', 'is-active', application]
+    try:
+        raw = check_output(cmd)
+        return b'active' in raw
+    except Exception:
+        return False

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -27,7 +27,8 @@ def _reconfigure_docker_for_sdn():
     This method removes the default docker bridge, and reconfigures the
     DOCKER_OPTS to use the flannel networking bridge '''
 
-    hookenv.status_set('maintenance', 'Reconfiguring docker network bridge')
+    hookenv.status_set('maintenance',
+                       'Reconfiguring container runtime network bridge.')
     host.service_stop('docker')
     apt_install(['bridge-utils'], fatal=True)
     # cmd = "ifconfig docker0 down"
@@ -56,23 +57,23 @@ def install_kubernetes_components():
     try:
         archive = hookenv.resource_get('kubernetes')
     except Exception:
-        message = 'Error fetching the kubernetes resource'
+        message = 'Error fetching the kubernetes resource.'
         hookenv.log(message)
         hookenv.status_set('blocked', message)
         return
 
     if not archive:
-        hookenv.log('Missing kubernetes resource')
-        hookenv.status_set('blocked', 'Missing kubernetes resource')
+        hookenv.log('Missing kubernetes resource.')
+        hookenv.status_set('blocked', 'Missing kubernetes resource.')
         return
 
     # Handle null resource publication, we check if filesize < 1mb
     filesize = os.stat(archive).st_size
     if filesize < 1000000:
-        hookenv.status_set('blocked', 'Incomplete kubernetes resource')
+        hookenv.status_set('blocked', 'Incomplete kubernetes resource.')
         return
 
-    hookenv.status_set('maintenance', 'Unpacking kubernetes')
+    hookenv.status_set('maintenance', 'Unpacking kubernetes resource.')
 
     unpack_path = '{}/files/kubernetes'.format(charm_dir)
     os.makedirs(unpack_path, exist_ok=True)
@@ -112,7 +113,7 @@ def notify_user_transient_status():
     # declared in the kube-system namespace
 
     hookenv.status_set('waiting',
-                       'Waiting for cluster-manager to initiate start')
+                       'Waiting for cluster-manager to initiate start.')
 
 
 @when('kubernetes.worker.bins.installed', 'kube-dns.available')
@@ -127,14 +128,13 @@ def notify_user_converging_status(kube_dns):
     # kubelet is running
     if (_systemctl_is_active('kubelet') and
        '--cluster-dns' not in kubelet_opts.data):
-        hookenv.status_set('waiting', 'Waiting on cluster dns')
+        hookenv.status_set('waiting', 'Waiting for cluster DNS.')
     elif(_systemctl_is_active('kubelet') and
          '--cluster-dns' in kubelet_opts.data):
-        hookenv.status_set('active',
-                           'Kubernetes worker running')
+        hookenv.status_set('active', 'Kubernetes worker running.')
     # if kubelet is not running, we're waiting on something else to converge
     elif(not _systemctl_is_active('kubelet')):
-        hookenv.status_set('waiting', 'waiting on kubelet')
+        hookenv.status_set('waiting', 'Waiting for kubelet to start.')
 
 
 @when('sdn-plugin.available', 'docker.available')
@@ -142,7 +142,8 @@ def notify_user_converging_status(kube_dns):
 def container_sdn_setup(sdn):
     ''' Receive the information from the SDN plugin, and render the docker
     engine options. '''
-    hookenv.status_set('maintenance', 'Configuring docker for sdn')
+    hookenv.status_set('maintenance',
+                       'Configuring container runtime with SDN.')
     sdn_config = sdn.get_sdn_config()
 
     opts = DockerOpts()


### PR DESCRIPTION
There are transient states during turn up that can be confusing to the end 
    user. This branch attempts to clean up those scenarios with clear messaging
    to the user to set expectations.                                           
                                                                               
    - kubelet is waiting on cluster dns                                        
    - kubelet is not running                                                   
    - kubelet needs to negotiate running the dns container with the master     
                                                                               
    Removes the caching `data_changed` stanza on the cluster certificates      
    management                                                                 
                                                                               
    Adds new tls-client states to guard against unwritten file race conditions 
    during turnup.