### PR TITLE
Move the expose declaration into the manifest, and provide

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -324,6 +324,7 @@ def launch_default_ingress_controller():
     render('default-http-backend.yaml', manifest, context)
 
     kubectl('create', manifest)
+
     # Render the ingress replication controller manifest
     manifest = addon_path.format('ingress-replication-controller.yaml')
     render('ingress-replication-controller.yaml', manifest, context)

--- a/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
@@ -27,3 +27,17 @@ spec:
           timeoutSeconds: 5
         ports:
         - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  labels:
+    app: default-http-backend
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: default-http-backend


### PR DESCRIPTION


default-http-backend as a service to establish endpoint routing out of
the box when ingress is enabled