### PR TITLE
scale ingress controller to the number of kubernetes-workers

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -203,6 +203,7 @@ def render_and_launch_ingress(kube_dns):
     # If ingress is enabled, launch the ingress controller and open ports
     if config.get('ingress'):
         launch_default_ingress_controller()
+        scale_ingress_controller()
         hookenv.open_port(80)
         hookenv.open_port(443)
     else:
@@ -211,6 +212,13 @@ def render_and_launch_ingress(kube_dns):
         hookenv.close_port(80)
         hookenv.close_port(443)
 
+def scale_ingress_controller():
+    kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
+    command = kubectl + ['get', 'nodes', '-o', 'name']
+    output = check_output(command, shell=False)
+    count = len(output.splitlines())
+    command = kubectl + ['scale', '--replicas=%d' % count, 'rc/nginx-ingress-controller']
+    check_call(command)
 
 def arch():
     '''Return the package architecture as a string. Raise an exception if the

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -354,15 +354,16 @@ def get_kube_api_servers(kube_api):
 
 
 def kubectl(*args):
+    ''' Run a kubectl cli command with a config file. Returns stdout and throws
+    an error if the command fails. '''
     command = ['kubectl', '--kubeconfig=/srv/kubernetes/config'] + list(args)
     hookenv.log('Executing {}'.format(command))
     return check_output(command)
 
 
 def kubectl_success(*args):
-    ''' Runs kubectl with the given args. Returns True if succesful, false if
-    not.
-    '''
+    ''' Runs kubectl with the given args. Returns True if succesful, False if
+    not. '''
     try:
         kubectl(*args)
         return True

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -214,6 +214,7 @@ def render_and_launch_ingress(kube_dns):
         hookenv.close_port(443)
 
 def scale_ingress_controller():
+    ''' Scale the number of ingress controller replicas to match the number of nodes. '''
     kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
     command = kubectl + ['get', 'nodes', '-o', 'name']
     output = check_output(command, shell=False)


### PR DESCRIPTION
@chuckbutler @mbruzek

Scales the ingress controller replica count to match the number of kubernetes-worker units.

We see a couple of issues with this PR:

1. There's a potential race condition wherein the controller replica count can be set to a value less than the number of kubernetes-worker units. It seems unlikely to occur, but we may need to look into placing this logic elsewhere or running it at some interval instead of only once.

2. The scaling appears to occur serially, at least how we're invoking it here. In our three-node microbot test, each nginx ingress pod took 11 minutes to reach a `Running` state, and it took 33 minutes before we were able to reach microbot because the last nginx ingress pod was the one selected by microbot to serve as its proxy.