### PR TITLE
Fix inotify leak by killing child processes

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/templates/kubelet.service
+++ b/cluster/juju/layers/kubernetes-worker/templates/kubelet.service
@@ -17,7 +17,6 @@ ExecStart=/usr/local/bin/kubelet \
 	    $KUBE_ALLOW_PRIV \
 	    $KUBELET_ARGS
 Restart=on-failure
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Don't merge yet - needs testing.

Proposed fix for cAdvisor "too many open files" error, which occurs when we hit the inotify instance limit defined by sysctl `fs.inotify.max_user_instances`.

Every time kubelet restarts, we see a leaked `journalctl -k -f` child process which is consuming inotify instances. Eventually, we hit the limit and can no longer start kubelet.

Fix is to remove `KillMode=process`, so we default to the `control-group` policy instead, which kills the whole process group.

Another factor in this is that `kubelet` is restarting every time the juju `update-status` hook runs - that is being looked into separately.

@chuckbutler @mbruzek @wwwtyro 