### PR TITLE
Remove sdn

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -30,6 +30,7 @@ def reset_states_for_delivery():
                 'kube-controller-manager',
                 'kube-scheduler']
     for service in services:
+        hookenv.log('Stopping {0} service.'.format(service))
         host.service_stop(service)
     remove_state('kubernetes-master.components.started')
     remove_state('kubernetes-master.components.installed')
@@ -143,6 +144,7 @@ def start_master(etcd, tls):
                 'kube-controller-manager',
                 'kube-scheduler']
     for service in services:
+        hookenv.log('Starting {0} service.'.format(service))
         host.service_start(service)
     hookenv.open_port(6443)
     hookenv.status_set('active', 'Kubernetes master services ready.')
@@ -224,6 +226,7 @@ def launch_kubernetes_dashboard():
     ''' Launch the Kubernetes dashboard. If not enabled, attempt deletion '''
     manifest = '/etc/kubernetes/addons/dashboard.yaml'
     if hookenv.config('dashboard'):
+        hookenv.log('Launching kubernetes dashboard.')
         context = {}
         context['arch'] = arch()
         render('kubernetes-dashboard.yaml', manifest, context)
@@ -231,6 +234,7 @@ def launch_kubernetes_dashboard():
         call(cmd)
         set_state('kubernetes.dashboard.available')
     else:
+        hookenv.log('Removing kubernetes dashboard.')
         cmd = ['kubectl', 'delete', '-f', manifest]
         try:
             call(cmd)
@@ -295,8 +299,9 @@ def create_self_config(ca, client):
 def launch_dns():
     '''Create the "kube-system" namespace, the kubedns resource controller, and
     the kubedns service. '''
-    hookenv.status_set('maintenance',
-                       'Rendering the Kubernetes DNS files.')
+    message = 'Rendering the Kubernetes DNS files.'
+    hookenv.log(message)
+    hookenv.status_set('maintenance', message)
     # Render the DNS files with the cider information.
     render_files()
     # Run a command to check if the apiserver is responding.

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -3,7 +3,6 @@ includes:
   - 'layer:docker'
   - 'layer:tls-client'
   - 'interface:http'
-  - 'interface:sdn-plugin'
   - 'interface:kube-dns'
 repo: https://github.com/kubernetes/kubernetes
 options:

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -14,10 +14,6 @@ tags:
 series:
   - xenial
 subordinate: false
-provides:
-  sdn-plugin:
-    interface: sdn-plugin
-    scope: container
 requires:
   kube-api-endpoint:
     interface: http
@@ -27,4 +23,4 @@ resources:
   kubernetes:
     type: file
     filename: kubernetes.tar.gz
-    description: "A tarball packaged release of the kubernetes bins."
+    description: "An archive of kubernetes binaries for the worker."

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -6,40 +6,19 @@ from subprocess import check_call
 from subprocess import check_output
 
 from charms import layer
-from charms.docker import DockerOpts
 from charms.reactive import hook
 from charms.reactive import remove_state
 from charms.reactive import set_state
 from charms.reactive import when
 from charms.reactive import when_not
+from charms.reactive.helpers import data_changed
 
 from charmhelpers.core import hookenv
-from charmhelpers.core import host
-from charmhelpers.fetch import apt_install
+from charmhelpers.core.host import restart_on_change
 
 from charms.kubernetes.flagmanager import FlagManager
 
 from charms.templating.jinja2 import render
-
-
-def _reconfigure_docker_for_sdn():
-    ''' By default docker uses the docker0 bridge for container networking.
-    This method removes the default docker bridge, and reconfigures the
-    DOCKER_OPTS to use the flannel networking bridge '''
-
-    hookenv.status_set('maintenance',
-                       'Reconfiguring container runtime network bridge.')
-    host.service_stop('docker')
-    apt_install(['bridge-utils'], fatal=True)
-    # cmd = "ifconfig docker0 down"
-    # ifconfig doesn't always work. use native linux networking commands to
-    # mark the bridge as inactive.
-    cmd = ['ip', 'link', 'set', 'docker0', 'down']
-    check_call(cmd)
-
-    cmd = ['brctl', 'delbr', 'docker0']
-    check_call(cmd)
-    set_state('docker.restart')
 
 
 @hook('upgrade-charm')
@@ -137,36 +116,19 @@ def notify_user_converging_status(kube_dns):
         hookenv.status_set('waiting', 'Waiting for kubelet to start.')
 
 
-@when('sdn-plugin.available', 'docker.available')
-@when_not('sdn.configured')
-def container_sdn_setup(sdn):
-    ''' Receive the information from the SDN plugin, and render the docker
-    engine options. '''
-    hookenv.status_set('maintenance',
-                       'Configuring container runtime with SDN.')
-    sdn_config = sdn.get_sdn_config()
-
-    opts = DockerOpts()
-    opts.add('bip', sdn_config['subnet'])
-    opts.add('mtu', sdn_config['mtu'])
-
-    with open('/etc/default/docker', 'w') as stream:
-        stream.write('DOCKER_OPTS="{}"'.format(opts.to_s()))
-    _reconfigure_docker_for_sdn()
-    set_state('sdn.configured')
-
-
 @when('kubernetes-worker.components.installed', 'kube-api-endpoint.available',
       'tls_client.ca.saved', 'tls_client.client.certificate.saved',
       'tls_client.client.key.saved')
 @when_not('kube-dns.available')
 def start_worker(kube_api):
-    '''We have related to either an api server or a load balancer connected
-    to the apiserver along with the certificate and keys. Render the init
-    scripts.'''
-    create_config(kube_api)
-    render_init_scripts(kube_api)
-    restart_unit_services()
+    '''Need to start the worker services before the api-server can schedule
+    required addons like DNS inside the workers.'''
+    # Get the list of kubernetes api servers from the relationship object.
+    servers = get_kube_api_servers(kube_api)
+    if data_changed('kube-api-servers', servers):
+        create_config(servers[0])
+        render_init_scripts(servers)
+        restart_unit_services()
 
 
 @when('kubernetes-worker.components.installed', 'kube-api-endpoint.available',
@@ -174,18 +136,21 @@ def start_worker(kube_api):
       'tls_client.client.key.saved', 'kube-dns.available')
 def render_dns_scripts(kube_api, kube_dns):
     ''' The dns is now available, re-render init config with DNS data. '''
+    # GEt the list of kubernetes api servers from the relationship object.
+    servers = get_kube_api_servers(kube_api)
     # Fetch the DNS data on the relationship.
     dns = kube_dns.details()
-    # Initialize a FlagManager object to add flags to unit data.
-    opts = FlagManager('kubelet')
-    # Append the DNS flags + data to the FlagManager object.
-    opts.add('--cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
-    opts.add('--cluster-domain', dns['domain'])
-
-    create_config(kube_api)
-    set_state('kubernetes-worker.config.created')
-    render_init_scripts(kube_api)
-    restart_unit_services()
+    if (data_changed('kube-api-servers', servers) or
+            data_changed('kube-dns', dns)):
+        # Initialize a FlagManager object to add flags to unit data.
+        opts = FlagManager('kubelet')
+        # Append the DNS flags + data to the FlagManager object.
+        opts.add('--cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
+        opts.add('--cluster-domain', dns['domain'])
+        create_config(servers[0])
+        render_init_scripts(servers)
+        set_state('kubernetes-worker.config.created')
+        restart_unit_services()
 
 
 @when('config.changed.ingress')
@@ -193,6 +158,26 @@ def toggle_ingress_state():
     ''' Ingress is a toggled state. Remove ingress.available if set when
     toggled '''
     remove_state('kubernetes-worker.ingress.available')
+
+
+@when('docker.sdn.configured')
+def sdn_changed():
+    '''The Software Defined Network changed on the container so restart the
+    kubernetes services.'''
+    restart_unit_services()
+    remove_state('docker.sdn.configured')
+
+
+@restart_on_change({
+    '/etc/default/docker': ['kubelet', 'kube-proxy'],
+    '/etc/default/kubelet': ['kubelet'],
+    '/lib/systemd/system/kubelet': ['kubelet'],
+    '/etc/default/kube-proxy': ['kube-proxy'],
+    '/lib/systemd/system/kube-proxy': ['kube-proxy'],
+})
+def restart_services():
+    '''When the configuration files change, restart the system services.'''
+    hookenv.log('Restart services was triggered.')
 
 
 @when('kubernetes-worker.config.created', 'kube-dns.available')
@@ -223,9 +208,8 @@ def arch():
     return architecture
 
 
-def create_config(kube_api):
+def create_config(server):
     '''Create a kubernetes configuration for the worker unit.'''
-    server = get_kube_api_server(kube_api)
     # Get the options from the tls-client layer.
     layer_options = layer.options('tls-client')
     # Get all the paths to the tls information required for kubeconfig.
@@ -247,7 +231,7 @@ def create_config(kube_api):
                       user='kubelet')
 
 
-def render_init_scripts(kube_api):
+def render_init_scripts(api_servers):
     ''' We have related to either an api server or a load balancer connected
     to the apiserver. Render the config files and prepare for launch '''
     context = {}
@@ -259,14 +243,8 @@ def render_init_scripts(kube_api):
     context['client_cert_path'] = layer_options.get('client_certificate_path')
     context['client_key_path'] = layer_options.get('client_key_path')
 
-    hosts = []
-    for serv in kube_api.services():
-        for unit in serv['hosts']:
-            hosts.append('https://{}:{}'.format(unit['hostname'],
-                                                unit['port']))
-            hookenv.log(hosts)
     unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '-')
-    context.update({'kube_api_endpoint': ','.join(hosts),
+    context.update({'kube_api_endpoint': ','.join(api_servers),
                     'JUJU_UNIT_NAME': unit_name})
 
     # Create a flag manager for kubelet to render kubelet_opts.
@@ -347,24 +325,16 @@ def restart_unit_services():
     call(['systemctl', 'restart', 'kube-proxy'])
 
 
-def get_kube_api_server(kube_api):
+def get_kube_api_servers(kube_api):
     '''Return the kubernetes api server address and port for this
     relationship.'''
-    # Get the services from the relation object.
-    services = kube_api.services()
-    # There is a bug where Kubernetes components do not handle multiple master
-    # or server addresses so only return one address from the list.
-    if len(services) > 0:
-        hosts = services[0]['hosts']
-        if len(hosts) > 0:
-            server = 'https://{0}:{1}'.format(hosts[0]['hostname'],
-                                              hosts[0]['port'])
-            hookenv.log('Using server: {0}'.format(server))
-        else:
-            hookenv.log('Unable to get "server" not enough hosts.')
-    else:
-        hookenv.log('Unable to get "server" not services.')
-    return server
+    hosts = []
+    # Iterate over every service from the relation object.
+    for service in kube_api.services():
+        for unit in service['hosts']:
+            hosts.append('https://{0}:{1}'.format(unit['hostname'],
+                                                  unit['port']))
+    return hosts
 
 
 def kubectl(operation, manifest):


### PR DESCRIPTION
- Moving the SDN code to the docker layer required some refactoring of this code.
- Changed the status messages to accommodate the SDN code move.
- Preventing the kubelet/kube-proxy restart on each reactive cycle with data_changed()
- Improved and updated the logging on both worker, and master
