### PR TITLE
Adds ceph-common to the worker packages

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -10,6 +10,7 @@ options:
   basic:
     packages:
       - 'nfs-common'
+      - 'ceph-common'
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
     server_certificate_path: '/srv/kubernetes/server.crt'


### PR DESCRIPTION
Ceph-Common is a required component to interact with ceph clusters.
Adding this to the worker packages works in tandem with the
create-rbd-pv action to enlist persistent volumes from a ceph-cluster
supporting the ceph-admin interface.