### PR TITLE
Fix kube-dns IP configuration

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -157,8 +157,8 @@ def start_master(etcd, tls):
 @when('kube-dns.available', 'cluster-dns.connected', 'sdn-plugin.available')
 def send_cluster_dns_detail(cluster_dns, sdn_plugin):
     details = sdn_plugin.get_sdn_config()
-    sdn_ip = get_dns_ip(details['cidr'])
-    cluster_dns.set_dns_info(53, hookenv.config('dns_domain'), sdn_ip)
+    dns_ip = get_dns_ip(details['cidr'])
+    cluster_dns.set_dns_info(53, hookenv.config('dns_domain'), dns_ip)
 
 
 @when('kube-api-endpoint.available')
@@ -542,7 +542,7 @@ def prepare_sdn_context(sdn_plugin=None):
     # The dictionary named 'pillar' is a construct of the k8s template files.
     pillar = {}
     # SDN Providers pass data via the sdn-plugin interface
-    # Ideally the DNS address should come from the sdn cidr, or subnet.
+    # Ideally the DNS address should come from the sdn cidr.
     plugin_data = sdn_plugin.get_sdn_config()
     if plugin_data.get('cidr'):
         # Generate the DNS ip address on the SDN cidr (this is desired).

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -544,9 +544,9 @@ def prepare_sdn_context(sdn_plugin=None):
     # SDN Providers pass data via the sdn-plugin interface
     # Ideally the DNS address should come from the sdn cidr, or subnet.
     plugin_data = sdn_plugin.get_sdn_config()
-    if plugin_data.get('subnet'):
+    if plugin_data.get('cidr'):
         # Generate the DNS ip address on the SDN cidr (this is desired).
-        pillar['dns_server'] = get_dns_ip(plugin_data['subnet'])
+        pillar['dns_server'] = get_dns_ip(plugin_data['cidr'])
     # The pillar['dns_server'] value is used the kubedns-svc.yaml file.
     pillar['dns_replicas'] = 1
     # The pillar['dns_domain'] value is used in the kubedns-rc.yaml

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -161,7 +161,7 @@ def render_dns_scripts(kube_api, kube_dns):
         # Initialize a FlagManager object to add flags to unit data.
         opts = FlagManager('kubelet')
         # Append the DNS flags + data to the FlagManager object.
-        opts.add('--cluster-dns', '{0}:{1}'.format(dns['sdn-ip'], dns['port']))
+        opts.add('--cluster-dns', dns['sdn-ip'])
         opts.add('--cluster-domain', dns['domain'])
         create_config(servers[0])
         render_init_scripts(servers)


### PR DESCRIPTION
Proposed fix for https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/105

The first problem is that kubelet does not pick up the `--cluster-dns=10.1.0.10:53` arg. As a result, pods/containers aren't being configured to use kube-dns. Looks like we're not supposed to pass in the port there, so the fix is to change it to `--cluster-dns=10.1.0.10`. This is a fix to kubernetes-worker.

The second problem is that the clusterIP of the `kube-dns` service differs from the one we send over the kube-dns relation. This happens because we use 'subnet' when calculating the clusterIP, but use 'cidr' when calculating it again to send over kube-dns. Fix this by using 'cidr' in both cases. This is a fix to kubernetes-master. @mbruzek this is the case we looked at yesterday.

Cc @chuckbutler @wwwtyro 