### PR TITLE
Remove the explicit SecurityContextDeny due to failures in e2e

### DIFF
--- a/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.defaults
+++ b/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.defaults
@@ -11,7 +11,7 @@ KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
 KUBE_API_PORT="--insecure-port=8080"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
+KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota"
 
 # Add your own!
 KUBE_API_ARGS="{{ kube_apiserver_flags }}"


### PR DESCRIPTION
E2E attempts to use container-level SELinux policy maps during it's
evaluation of the cluster, despite having that access control policy
disabled in the apiserver. We will never pass E2e with this enabled.

addresses:
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/106