### PR TITLE
dashboard reactive fixes

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -224,10 +224,9 @@ def gather_sdn_data(sdn_plugin):
       'kubernetes.dashboard.available')
 def reset_states():
     remove_state('kubernetes.dashboard.available')
-    launch_kubernetes_dashboard()
 
 
-@when('kube-dns.available')
+@when('kube-dns.available', 'kubernetes-master.components.started')
 @when_not('kubernetes.dashboard.available')
 def launch_kubernetes_dashboard():
     ''' Launch the Kubernetes dashboard. If not enabled, attempt deletion '''


### PR DESCRIPTION
Cleaning up my mess! This fixes two problems:

1. Hook failed during `upgrade-charm`
2. Infinite loop between `launch_kubernetes_dashboard` and `reset_states`

#### Testing checklist
- [x] Test upgrade-charm path :+1:
- [x] Test enabling and disabling `enable-dashboard-addons` config :+1:
- [x] Test new deploy of kubernetes-master :+1:

@chuckbutler @mbruzek 