### PR TITLE
e2e junit output

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -15,8 +15,21 @@ then
 fi
 
 # get the host from the config file
-SERVER=$(cat /home/ubuntu/.kube/config | grep server | sed 's/    server://')
+SERVER=$(cat /home/ubuntu/.kube/config | grep server | sed 's/    server: //')
 
-ginkgo -nodes=$PARALLELISM $(which e2e.test) -- -kubeconfig /home/ubuntu/.kube/config -host $SERVER -ginkgo.focus $FOCUS -ginkgo.skip "$SKIP" 2>&1 | tee /home/ubuntu/${JUJU_ACTION_UUID}.log
+ACTION_HOME=/home/ubuntu
+ACTION_LOG=$ACTION_HOME/${JUJU_ACTION_UUID}.log
+ACTION_JUNIT=$ACTION_HOME/${JUJU_ACTION_UUID}-junit
+ACTION_JUNIT_TGZ=$ACTION_JUNIT.tar.gz
 
-action-set result.output=$(cat /home/ubuntu/${JUJU_ACTION_UUID}.log)
+ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
+  -kubeconfig /home/ubuntu/.kube/config \
+  -host $SERVER \
+  -ginkgo.focus $FOCUS \
+  -ginkgo.skip "$SKIP" \
+  -report-dir $ACTION_JUNIT 2>&1 | tee $ACTION_LOG
+
+tar -cf $ACTION_JUNIT_TGZ $ACTION_JUNIT
+
+action-set log="$ACTION_LOG"
+action-set junit="$ACTION_JUNIT_TGZ"

--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -19,6 +19,7 @@ SERVER=$(cat /home/ubuntu/.kube/config | grep server | sed 's/    server: //')
 
 ACTION_HOME=/home/ubuntu
 ACTION_LOG=$ACTION_HOME/${JUJU_ACTION_UUID}.log
+ACTION_LOG_TGZ=$ACTION_LOG.tar.gz
 ACTION_JUNIT=$ACTION_HOME/${JUJU_ACTION_UUID}-junit
 ACTION_JUNIT_TGZ=$ACTION_JUNIT.tar.gz
 
@@ -29,7 +30,8 @@ ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
   -ginkgo.skip "$SKIP" \
   -report-dir $ACTION_JUNIT 2>&1 | tee $ACTION_LOG
 
-tar -cf $ACTION_JUNIT_TGZ $ACTION_JUNIT
+tar -czf $ACTION_LOG_TGZ $ACTION_LOG
+tar -czf $ACTION_JUNIT_TGZ $ACTION_JUNIT
 
-action-set log="$ACTION_LOG"
+action-set log="$ACTION_LOG_TGZ"
 action-set junit="$ACTION_JUNIT_TGZ"


### PR DESCRIPTION
@chuckbutler @mbruzek @Cynerva 
```
$ juju run-action kubernetes-e2e/1 test
Action queued with id: c81fa448-c25f-4180-84fe-fdda4a180bda

$ juju show-action-output c81fa448-c25f-4180-84fe-fdda4a180bda
results:
  junit: /home/ubuntu/c81fa448-c25f-4180-84fe-fdda4a180bda-junit.tar.gz
  log: /home/ubuntu/c81fa448-c25f-4180-84fe-fdda4a180bda.log
status: completed
timing:
  completed: 2016-11-02 15:50:59 +0000 UTC
  enqueued: 2016-11-02 15:44:31 +0000 UTC
  started: 2016-11-02 15:44:35 +0000 UTC
```