### PR TITLE
Fixes for the kubernetes-worker microbot action

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -6,12 +6,12 @@ resume:
       UnCordon the unit, enabling workload scheduling.
 microbot:
     description: Launch microbot containers
-    options:
+    params:
       replicas:
-        type: int
+        type: integer
         default: 3
         description: Number of microbots to launch in Kubernetes.
       delete:
-        type: bool
+        type: boolean
         default: False
         description: Removes a microbots deployment, service, and ingress if True.

--- a/cluster/juju/layers/kubernetes-worker/actions/microbot
+++ b/cluster/juju/layers/kubernetes-worker/actions/microbot
@@ -14,6 +14,9 @@ context['replicas'] = action_get('replicas')
 context['delete'] = action_get('delete')
 context['public_address'] = unit_public_ip()
 
+if not context['replicas']:
+    context['replicas'] = 3
+
 # Declare a kubectl template when invoking kubectl
 kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
 


### PR DESCRIPTION
The action would fail randomly if not being explicit on the CLI when
launching microbot replicas.

proof

```
ubuntu@charmbox:~/builds$ juju run-action kubernetes-worker/0 microbot
Action queued with id: dc68c6bd-4e3c-4414-8844-9346abda6ef1
ubuntu@charmbox:~/builds$ juju show-action-output dc68c6bd-4e3c-4414-8844-9346abda6ef1
results:
  address: microbot.104.196.127.232.xip.io
status: completed
timing:
  completed: 2016-11-04 16:31:53 +0000 UTC
  enqueued: 2016-11-04 16:31:48 +0000 UTC
  started: 2016-11-04 16:31:53 +0000 UTC
```