### PR TITLE
Add support for node labels

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -5,3 +5,9 @@ options:
     description: |
       Deploy the default http backend and ingress controller to handle
       ingress requests.
+  labels:
+    type: string
+    default: ""
+    description: |
+      Labels can be used to organize and to select subsets of nodes in the
+      cluster. Declare node labels in key=value format, separated by spaces.


### PR DESCRIPTION
juju config kubernetes-worker1 labels="foo=bar"
juju config kubernetes-worker2 labels="bar=baz"

you can verify the labels were set with:

kubectl get no --show-labels

This was part of a request by @rimusz 