### PR TITLE
Remove addon states when upgrading the charm

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -47,6 +47,8 @@ def reset_states_for_delivery():
         host.service_stop(service)
     remove_state('kubernetes-master.components.started')
     remove_state('kubernetes-master.components.installed')
+    remove_state('kube-dns.available')
+    remove_state('kubernetes.dashboard.available')
 
 
 @when_not('kubernetes-master.components.installed')


### PR DESCRIPTION
This will cause us to re-render addon templates and redo `kubectl apply` on kube-dns and dashboard addons.

Thanks to some nicely idempotent reactive code, looks like we can just clear the states and let 'em go. Yay!

[Juju log output](https://gist.github.com/Cynerva/d4bc4d79f9dcc05bf8161a65b0c0bfbc) from an upgrade-charm test run looks good. I was able to add annotations to the addon templates, build kubernetes-master, juju upgrade-charm, and see the annotations show up in the k8s cluster.