### PR TITLE
Refactor the pathing on the tar archives

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -30,8 +30,11 @@ ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
   -ginkgo.skip "$SKIP" \
   -report-dir $ACTION_JUNIT 2>&1 | tee $ACTION_LOG
 
-tar -czf $ACTION_LOG_TGZ $ACTION_LOG
-tar -czf $ACTION_JUNIT_TGZ $ACTION_JUNIT
+# set cwd to /home/ubuntu and tar the artifacts using a minimal directory
+# path. Extracing "home/ubuntu/1412341234/foobar.log is cumbersome in ci
+cd $ACTION_HOME
+tar -czf $ACTION_LOG_TGZ ${JUJU_ACTION_UUID}.log
+tar -czf $ACTION_JUNIT_TGZ ${JUJU_ACTION_UUID}-junit/*
 
 action-set log="$ACTION_LOG_TGZ"
 action-set junit="$ACTION_JUNIT_TGZ"

--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -32,9 +32,10 @@ ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
 
 # set cwd to /home/ubuntu and tar the artifacts using a minimal directory
 # path. Extracing "home/ubuntu/1412341234/foobar.log is cumbersome in ci
-cd $ACTION_HOME
+cd $ACTION_HOME/${JUJU_ACTION_UUID}-junit
+tar -czf $ACTION_JUNIT_TGZ *
+cd ..
 tar -czf $ACTION_LOG_TGZ ${JUJU_ACTION_UUID}.log
-tar -czf $ACTION_JUNIT_TGZ ${JUJU_ACTION_UUID}-junit/*
 
 action-set log="$ACTION_LOG_TGZ"
 action-set junit="$ACTION_JUNIT_TGZ"


### PR DESCRIPTION
Extracing junit files to 'home/ubuntu/foobar-junit/*.xml' was going to
be painful in CI, as we would have to scrub every archive that comes
from the e2e charm. This is an attempt to clean up that output pathing
by dropping the home/ubuntu portion of the path.