### PR TITLE
Updates the test action to embed the start/end and version

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -23,12 +23,18 @@ ACTION_LOG_TGZ=$ACTION_LOG.tar.gz
 ACTION_JUNIT=$ACTION_HOME/${JUJU_ACTION_UUID}-junit
 ACTION_JUNIT_TGZ=$ACTION_JUNIT.tar.gz
 
+# This initializes an e2e build log with the START TIMESTAMP.
+echo "JUJU_E2E_START=$(date -u +%s)" | tee $ACTION_LOG
+echo "JUJU_E2E_VERSION=$(kubectl version | grep Server | cut -d " " -f 5 | cut -d ":" -f 2 | sed s/\"// | sed s/\",//)" | tee -a $ACTION_LOG
 ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
   -kubeconfig /home/ubuntu/.kube/config \
   -host $SERVER \
   -ginkgo.focus $FOCUS \
   -ginkgo.skip "$SKIP" \
-  -report-dir $ACTION_JUNIT 2>&1 | tee $ACTION_LOG
+  -report-dir $ACTION_JUNIT 2>&1 | tee -a $ACTION_LOG
+
+# This appends the END TIMESTAMP to the e2e build log
+echo "JUJU_E2E_END=$(date -u +%s)" | tee -a $ACTION_LOG
 
 # set cwd to /home/ubuntu and tar the artifacts using a minimal directory
 # path. Extracing "home/ubuntu/1412341234/foobar.log is cumbersome in ci


### PR DESCRIPTION
This adds time from epoch to both start/finished portions of the log,
and parses the server version from kubectl output.