### PR TITLE
Add debug scripts to kubernetes-master

### DIFF
--- a/cluster/juju/layers/kubernetes-master/debug-scripts/kubectl
+++ b/cluster/juju/layers/kubernetes-master/debug-scripts/kubectl
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ux
+
+alias kubectl="kubectl --kubeconfig=/home/ubuntu/config"
+
+kubectl cluster-info > $DEBUG_SCRIPT_DIR/cluster-info
+kubectl cluster-info dump > $DEBUG_SCRIPT_DIR/cluster-info-dump
+for obj in pods svc ingress secrets pv pvc rc; do
+  kubectl describe $obj --all-namespaces > $DEBUG_SCRIPT_DIR/describe-$obj
+done
+for obj in nodes; do
+  kubectl describe $obj > $DEBUG_SCRIPT_DIR/describe-$obj
+done

--- a/cluster/juju/layers/kubernetes-master/debug-scripts/kubernetes-master-services
+++ b/cluster/juju/layers/kubernetes-master/debug-scripts/kubernetes-master-services
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ux
+
+for service in kube-apiserver kube-controller-manager kube-scheduler; do
+  systemctl status $service > $DEBUG_SCRIPT_DIR/$service-systemctl-status
+  journalctl -u $service > $DEBUG_SCRIPT_DIR/$service-journal
+done
+
+mkdir -p $DEBUG_SCRIPT_DIR/etc-default
+cp /etc/default/kube* $DEBUG_SCRIPT_DIR/etc-default
+
+mkdir -p $DEBUG_SCRIPT_DIR/lib-systemd-system
+cp /lib/systemd/system/kube* $DEBUG_SCRIPT_DIR/lib-systemd-system

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -2,6 +2,7 @@ repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
   - 'layer:tls-client'
+  - 'layer:debug'
   - 'interface:etcd'
   - 'interface:http'
   - 'interface:sdn-plugin'

--- a/cluster/juju/layers/kubernetes-worker/debug-scripts/kubernetes-worker-services
+++ b/cluster/juju/layers/kubernetes-worker/debug-scripts/kubernetes-worker-services
@@ -1,8 +1,10 @@
 #!/bin/sh
 set -ux
 
-systemctl status kubelet > $DEBUG_SCRIPT_DIR/kubelet-systemctl-status
-journalctl -u kubelet > $DEBUG_SCRIPT_DIR/kubelet-journal
+for service in kubelet kube-proxy; do
+  systemctl status $service > $DEBUG_SCRIPT_DIR/$service-systemctl-status
+  journalctl -u $service > $DEBUG_SCRIPT_DIR/$service-journal
+done
 
 mkdir -p $DEBUG_SCRIPT_DIR/etc-default
 cp /etc/default/kube* $DEBUG_SCRIPT_DIR/etc-default


### PR DESCRIPTION
This adds the `debug` action to `kubernetes-master`, with debug scripts to grab info for the master services and from kubectl.

Also made a small change to `kubernetes-worker` debug scripts to grab info for the `kube-proxy` service as well.

@chuckbutler @mbruzek @wwwtyro 