### PR TITLE
Update kubedns addon template names to match upstream

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -309,7 +309,7 @@ def start_kube_dns():
             'dns_domain': hookenv.config('dns_domain')
         }
     }
-    create_addon('kubedns-rc.yaml', context)
+    create_addon('kubedns-controller.yaml', context)
     create_addon('kubedns-svc.yaml', context)
     set_state('kube-dns.available')
 

--- a/cluster/juju/layers/kubernetes-master/tactics/update_addons.py
+++ b/cluster/juju/layers/kubernetes-master/tactics/update_addons.py
@@ -61,8 +61,8 @@ def update_addons(dest):
     with kubernetes_repo() as repo:
         add_addon(repo + "/cluster/addons/dashboard/dashboard-controller.yaml", dest)
         add_addon(repo + "/cluster/addons/dashboard/dashboard-service.yaml", dest)
-        add_addon(repo + "/cluster/addons/dns/skydns-rc.yaml.in", dest + "/kubedns-rc.yaml")
-        add_addon(repo + "/cluster/addons/dns/skydns-svc.yaml.in", dest + "/kubedns-svc.yaml")
+        add_addon(repo + "/cluster/addons/dns/kubedns-controller.yaml.in", dest + "/kubedns-controller.yaml")
+        add_addon(repo + "/cluster/addons/dns/kubedns-svc.yaml.in", dest + "/kubedns-svc.yaml")
         add_addon(repo + "/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml", dest)
         add_addon(repo + "/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml", dest)
         add_addon(repo + "/cluster/addons/cluster-monitoring/influxdb/heapster-service.yaml", dest)


### PR DESCRIPTION
Catching up with an upstream change, see https://github.com/kubernetes/kubernetes/commit/4ad06df18f3e269095f758cb9ef5f7b5f985facb

Build tested. Have not tested a deployment yet.