### PR TITLE
Wait for DNS before deploying dashboard addons

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -250,7 +250,7 @@ def push_api_data(kube_api):
     kube_api.set_api_port('6443')
 
 
-@when('kubernetes-master.components.started')
+@when('kubernetes-master.components.started', 'kube-dns.available')
 @when_not('kubernetes.dashboard.available')
 def install_dashboard_addons():
     ''' Launch dashboard addons if they are enabled in config '''


### PR DESCRIPTION
Fixes an occasional failure where kube-dns and kubernetes-dashboard can end up competing for the same IP.

Needs testing.

@mbruzek 