### PR TITLE
kubectl classic snap

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions/microbot
+++ b/cluster/juju/layers/kubernetes-worker/actions/microbot
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 import sys
 
 from charmhelpers.core.hookenv import action_get
@@ -8,6 +9,7 @@ from charmhelpers.core.hookenv import unit_public_ip
 from charms.templating.jinja2 import render
 from subprocess import call
 
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 context = {}
 context['replicas'] = action_get('replicas')

--- a/cluster/juju/layers/kubernetes-worker/actions/pause
+++ b/cluster/juju/layers/kubernetes-worker/actions/pause
@@ -2,6 +2,8 @@
 
 set -ex
 
+export PATH=$PATH:/snap/bin
+
 kubectl --kubeconfig=/srv/kubernetes/config cordon $(hostname)
 kubectl --kubeconfig=/srv/kubernetes/config drain $(hostname) --force
 status-set 'waiting' 'Kubernetes unit paused'

--- a/cluster/juju/layers/kubernetes-worker/actions/resume
+++ b/cluster/juju/layers/kubernetes-worker/actions/resume
@@ -2,5 +2,7 @@
 
 set -ex
 
+export PATH=$PATH:/snap/bin
+
 kubectl --kubeconfig=/srv/kubernetes/config uncordon $(hostname)
 status-set 'active' 'Kubernetes unit resumed'

--- a/cluster/juju/layers/kubernetes-worker/debug-scripts/kubectl
+++ b/cluster/juju/layers/kubernetes-worker/debug-scripts/kubectl
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -ux
 
+export PATH=$PATH:/snap/bin
+
 alias kubectl="kubectl --kubeconfig=/srv/kubernetes/config"
 
 kubectl cluster-info > $DEBUG_SCRIPT_DIR/cluster-info

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -1,6 +1,7 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
+  - 'layer:snap'
   - 'layer:docker'
   - 'layer:tls-client'
   - 'layer:debug'
@@ -13,6 +14,13 @@ options:
       - 'nfs-common'
       - 'ceph-common'
       - 'socat'
+  snap:
+    kubectl:
+      channel: edge
+      devmode: false
+      jailmode: false
+      dangerous: false
+      classic: true
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
     server_certificate_path: '/srv/kubernetes/server.crt'

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -21,6 +21,12 @@ options:
       jailmode: false
       dangerous: false
       classic: true
+    kubelet:
+      channel: edge
+      devmode: false
+      jailmode: false
+      dangerous: false
+      classic: true
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
     server_certificate_path: '/srv/kubernetes/server.crt'

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -28,3 +28,7 @@ resources:
     type: file
     filename: kubernetes.tar.gz
     description: "An archive of kubernetes binaries for the worker."
+  kubectl:
+    type: file
+    filename: kubectl.snap
+    description: kubectl snap

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -32,3 +32,7 @@ resources:
     type: file
     filename: kubectl.snap
     description: kubectl snap
+  kubelet:
+    type: file
+    filename: kubelet.snap
+    description: kubelet snap

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -19,6 +19,7 @@ from charmhelpers.core.host import service_stop
 
 kubeconfig_path = '/srv/kubernetes/config'
 
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 @hook('upgrade-charm')
 def remove_installed_state():
@@ -76,7 +77,6 @@ def install_kubernetes_components():
     apps = [
         {'name': 'kubelet', 'path': '/usr/local/bin'},
         {'name': 'kube-proxy', 'path': '/usr/local/bin'},
-        {'name': 'kubectl', 'path': '/usr/local/bin'},
         {'name': 'loopback', 'path': '/opt/cni/bin'}
     ]
 

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -76,7 +76,6 @@ def install_kubernetes_components():
     check_call(cmd)
 
     apps = [
-        {'name': 'kube-proxy', 'path': '/usr/local/bin'},
         {'name': 'loopback', 'path': '/opt/cni/bin'}
     ]
 

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -21,6 +21,7 @@ kubeconfig_path = '/srv/kubernetes/config'
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
+
 @hook('upgrade-charm')
 def remove_installed_state():
     remove_state('kubernetes-worker.components.installed')
@@ -75,7 +76,6 @@ def install_kubernetes_components():
     check_call(cmd)
 
     apps = [
-        {'name': 'kubelet', 'path': '/usr/local/bin'},
         {'name': 'kube-proxy', 'path': '/usr/local/bin'},
         {'name': 'loopback', 'path': '/opt/cni/bin'}
     ]
@@ -148,8 +148,7 @@ def start_worker(kube_api, kube_dns, cni):
         # Initialize a FlagManager object to add flags to unit data.
         opts = FlagManager('kubelet')
         # Append the DNS flags + data to the FlagManager object.
-
-        opts.add('--cluster-dns', dns['sdn-ip']) # FIXME: sdn-ip needs a rename
+        opts.add('--cluster-dns', dns['sdn-ip'])  # FIXME: sdn-ip needs rename
         opts.add('--cluster-domain', dns['domain'])
 
         create_config(servers[0])

--- a/cluster/juju/layers/kubernetes-worker/templates/kube-proxy.service
+++ b/cluster/juju/layers/kubernetes-worker/templates/kube-proxy.service
@@ -7,7 +7,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/kube-default
 EnvironmentFile=-/etc/default/kube-proxy
-ExecStart=/usr/local/bin/kube-proxy \
+ExecStart=/snap/bin/kube-proxy \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \
 	    $KUBE_MASTER \

--- a/cluster/juju/layers/kubernetes-worker/templates/kubelet.service
+++ b/cluster/juju/layers/kubernetes-worker/templates/kubelet.service
@@ -8,7 +8,7 @@ Requires=docker.service
 WorkingDirectory=/var/lib/kubelet
 EnvironmentFile=-/etc/default/kube-default
 EnvironmentFile=-/etc/default/kubelet
-ExecStart=/usr/local/bin/kubelet \
+ExecStart=/snap/bin/kubelet \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \
 	    $KUBELET_ADDRESS \


### PR DESCRIPTION
**DO NOT MERGE**

This PR prototypes installing kubectl as a snap instead of as a resource. Users can optionally install kubectl via the resource path by providing a kubectl snap of their own.

A few things need to happen before this can be a thing:

- I'd like to see this bug resolved beyond manual verification of classic snaps: https://bugs.launchpad.net/snapcraft/+bug/1655637 otherwise life is gonna be hard
- merge layer-snap bugfix: https://github.com/stub42/layer-snap/pull/1
- merge layer-snap classic confinement support: https://github.com/stub42/layer-snap/pull/1
