### PR TITLE
Allow the nginx-ingress-controller to be configured by a configmap

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-replication-controller.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-replication-controller.yaml
@@ -45,3 +45,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --nginx-configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf


### PR DESCRIPTION
This resolves https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/186