### PR TITLE
workaround for offline installs

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/exec.d/docker-compose/charm-pre-install
+++ b/cluster/juju/layers/kubernetes-worker/exec.d/docker-compose/charm-pre-install
@@ -1,0 +1,2 @@
+# This stubs out charm-pre-install coming from layer-docker as a workaround for 
+# offline installs until https://github.com/juju/charm-tools/issues/301 is fixed.


### PR DESCRIPTION
This stubs out charm-pre-install coming from layer-docker as a workaround for offline installs until https://github.com/juju/charm-tools/issues/301 is fixed.
