### PR TITLE
Turning off proxy buffering for issue #172.

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
+++ b/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
@@ -23,6 +23,7 @@ server {
 
 
     location / {
+      proxy_buffering         off;
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
We noticed some errors in e2e testing with our internal nginx load balancer. This PR turns off proxy_buffering in the nginx configuration to speed the requests to the api-server.

https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/172