### PR TITLE
Adds Restart action

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/README.md
+++ b/cluster/juju/layers/kubernetes-worker/README.md
@@ -36,6 +36,25 @@ The kubernetes-worker charm supports the following Operational Actions:
 Pausing the workload enables administrators to both [drain](http://kubernetes.io/docs/user-guide/kubectl/kubectl_drain/) and [cordon](http://kubernetes.io/docs/user-guide/kubectl/kubectl_cordon/)
 a unit for maintenance.
 
+Parameter force:  This will force deletion of pods utilizing local storage.
+See the [attached bug](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/200)
+for details on why this paramter exists. It can be potentially destructive, so
+use with care.
+
+
+#### Restart
+
+Restart will cycle the kubernetes-worker services in the event of node degradation
+without the need for a full system restart. This can often be caused by docker
+deadlocking bugs, and resolved by simply cycling the service(s) in degradation.
+
+This will restart: `kubelet`, and `kube-proxy` services by default.
+
+Parameter docker: Include cycling the docker daemon service during the restart
+request
+
+Parameter force: Skip any attempt to pause/cordon the unit during service cycling.
+
 
 #### Resume
 

--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -1,9 +1,26 @@
 pause:
     description: |
       Cordon the unit, draining all active workloads.
+    params:
+      force:
+        type: boolean
+        default: False
+        description: Force drain/cordon to remove units with local storage.
 resume:
     description: |
       UnCordon the unit, enabling workload scheduling.
+restart:
+    description: |
+      Restart the kubernetes-worker services
+    params:
+      docker:
+        type: boolean
+        default: False
+        description: Cycle the docker daemon
+      force:
+        type: boolean
+        default: False
+        description: Skip pause/cordoning of the worker-unit during restart.
 microbot:
     description: Launch microbot containers
     params:

--- a/cluster/juju/layers/kubernetes-worker/actions/pause
+++ b/cluster/juju/layers/kubernetes-worker/actions/pause
@@ -2,6 +2,18 @@
 
 set -ex
 
+FORCE_LOCAL=$(action-get force)
+
 kubectl --kubeconfig=/srv/kubernetes/config cordon $(hostname)
-kubectl --kubeconfig=/srv/kubernetes/config drain $(hostname) --force
+
+if [ ${FORCE_LOCAL} == True ]; then
+  # NOTE: This action reads FORCE from the RESTART action as well, and uses it
+  # in the appropriate context. Please ensure you evaluate both code paths before
+  # changing this behavior.
+  kubectl --kubeconfig=/srv/kubernetes/config drain $(hostname) --force --delete-local-data
+else
+  # The default FORCE will not delete local storage, and may fail, however this
+  # is the default behavior.
+  kubectl --kubeconfig=/srv/kubernetes/config drain $(hostname) --force
+fi
 status-set 'waiting' 'Kubernetes unit paused'

--- a/cluster/juju/layers/kubernetes-worker/actions/restart
+++ b/cluster/juju/layers/kubernetes-worker/actions/restart
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+# Initiate a service restart without the requirement of rebooting the unit.
+# Optional parameters:
+# force: - Do not pause/cordon the unit during service restart
+# docker: - Cycle the docker daemon during the kubernetes-worker service reboot
+
+FORCE=$(action-get force)
+DOCKER=$(action-get docker)
+
+# Force restarts are kind of a bonzai thing. We're not concerned with the
+# Workloads contained therein, so forcibly recycle the services and exit 0.
+
+if [ ${FORCE} == "True" ]; then
+
+  if [ ${DOCKER} == "True" ]; then
+    systemctl "Force restarting docker service..."
+    systemctl restart docker
+  fi
+
+  juju-log "Force restarting kubernetes-worker services..."
+  systemctl restart kubelet
+  systemctl restart kube-proxy
+
+  exit 0
+fi
+
+# Non force restarts below
+
+# Pause the unit, and cordon so no additional workloads get scheduled during
+# the restart.
+juju-log "Pausing kubernetes-worker services"
+actions/pause
+
+systemctl restart kubelet
+systemctl restart kube-proxy
+
+if [ ${DOCKER} == "True" ]; then
+  systemctl "Restarting docker service during service interruption..."
+  systemctl restart docker
+fi
+
+juju-log "Resuming service"
+actions/resume


### PR DESCRIPTION
This addresses a potential fix for services entering a degraded state
that would otherwise require a unit restart. Often times
docker-deadlocking bugs will cause kubernetes nodes to enter a
"not-ready" state when they have reached a "mature" running stage of >
10 days at present soak testing.

This also adds a potential fix for the issue
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/200

where the pause action now fails with stateful applications not using
the stateful-set object type. Kubernetes-addons are using EMPTYDIR
storage, and the pause action will fail 100% of the time without forcing
the deletion of local storage on pods. This can be potentially dangerous
to use so use with caution.