### PR TITLE
snapped kube-apiserver with classic confinement

### DIFF
--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -1,6 +1,7 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
+  - 'layer:snap'
   - 'layer:tls-client'
   - 'layer:debug'
   - 'interface:etcd'
@@ -13,6 +14,13 @@ options:
   basic:
     packages:
       - socat
+  snap:
+    kube-apiserver:
+      channel: edge
+      devmode: false
+      jailmode: false
+      dangerous: false
+      classic: true
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
     server_certificate_path: '/srv/kubernetes/server.crt'

--- a/cluster/juju/layers/kubernetes-master/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-master/metadata.yaml
@@ -36,3 +36,7 @@ resources:
     type: file
     filename: kubernetes.tar.gz
     description: "A tarball packaged release of the kubernetes bins."
+  kube-apiserver:
+    type: file
+    filename: kube-apiserver.snap
+    description: kube-apiserver snap

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -27,6 +27,9 @@ from charmhelpers.core.templating import render
 from charmhelpers.fetch import apt_install
 
 
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
+
+
 dashboard_templates = [
     'dashboard-controller.yaml',
     'dashboard-service.yaml',
@@ -100,7 +103,6 @@ def install():
     check_call(split(command))
 
     apps = [
-        {'name': 'kube-apiserver', 'path': '/usr/local/bin'},
         {'name': 'kube-controller-manager', 'path': '/usr/local/bin'},
         {'name': 'kube-scheduler', 'path': '/usr/local/bin'},
         {'name': 'kubectl', 'path': '/usr/local/bin'},

--- a/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.service
+++ b/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/default/kube-defaults
 EnvironmentFile=-/etc/default/kube-apiserver
-ExecStart=/usr/local/bin/kube-apiserver \
+ExecStart=/snap/bin/kube-apiserver \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \
 	    $KUBE_API_ADDRESS \


### PR DESCRIPTION
**DO NOT MERGE**

Uses the kube-apiserver snap (generated [here](https://github.com/juju-solutions/snap-kube-apiserver)). The snap uses classic confinement, and the changes here are the bare minimum to enable snap usage.

There's a couple of PRs for layer-snap we need to get merged:

 - https://github.com/stub42/layer-snap/pull/1
 - https://github.com/stub42/layer-snap/pull/3

Everything's tested and appears fine. You can find my test bundle here: https://jujucharms.com/u/ryeterrell/cdk-kubeapi-snap