### PR TITLE
Putting the nvidia-smi command in a try catch to avoid errors.

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -665,6 +665,15 @@ def enable_gpu():
         return
 
     hookenv.log('Enabling gpu mode')
+    try:
+        # Not sure why this is necessary, but if you don't run this, k8s will
+        # think that the node has 0 gpus (as shown by the output of
+        # `kubectl get nodes -o yaml`
+        check_call(['nvidia-smi'])
+    except CalledProcessError as cpe:
+        hookenv.log('Unable to communicate with the NVIDIA driver.')
+        hookenv.log(cpe)
+        return
 
     kubelet_opts = FlagManager('kubelet')
     if get_version('kubelet') < (1, 6):
@@ -677,11 +686,6 @@ def enable_gpu():
     # Apply node labels
     _apply_node_label('gpu=true', overwrite=True)
     _apply_node_label('cuda=true', overwrite=True)
-
-    # Not sure why this is necessary, but if you don't run this, k8s will
-    # think that the node has 0 gpus (as shown by the output of
-    # `kubectl get nodes -o yaml`
-    check_call(['nvidia-smi'])
 
     set_state('kubernetes-worker.gpu.enabled')
     set_state('kubernetes-worker.restart-needed')


### PR DESCRIPTION
Got an error on my GPU system in LXD, this fix proved to not get the error.

```
rker/0.cni-relation-changed node "juju-4bcd19-3" not labeled
unit-kubernetes-worker-0: 15:23:13 INFO unit.kubernetes-worker/0.cni-relation-changed node "juju-4bcd19-3" not labeled
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is
 installed and running.
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed 
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed Traceback (most recent call last):
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/hooks/cni-relation-changed", line 19, in <module>
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     main()
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/usr/local/lib/python3.5/dist-packages/charms/reactive/__init__.py", line 78, in main
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     bus.dispatch()
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/usr/local/lib/python3.5/dist-packages/charms/reactive/bus.py", line 434, in dispatch
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     _invoke(other_handlers)
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/usr/local/lib/python3.5/dist-packages/charms/reactive/bus.py", line 417, in _invoke
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     handler.invoke()
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/usr/local/lib/python3.5/dist-packages/charms/reactive/bus.py", line 291, in invoke
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     self._action(*args)
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/var/lib/juju/agents/unit-kubernetes-worker-0/charm/reactive/kubernetes_worker.py", line 684, in enable_gpu
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     check_call(['nvidia-smi'])
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed   File "/usr/lib/python3.5/subprocess.py", line 581, in check_call
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed     raise CalledProcessError(retcode, cmd)
unit-kubernetes-worker-0: 15:23:14 INFO unit.kubernetes-worker/0.cni-relation-changed subprocess.CalledProcessError: Command '['nvidia-smi']' returned non-zero exit status 9
unit-kubernetes-worker-0: 15:23:14 ERROR juju.worker.uniter.operation hook "cni-relation-changed" failed: exit status 1
```