### PR TITLE
Enable RBAC / Auth Changes

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -26,3 +26,7 @@ options:
     default: "stable"
     description: |
       Snap channel to install Kubernetes master services from
+  authorization-mode:
+    type: string
+    default: "RBAC"
+    description: kube-apiserver --authorization-mode <value>

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -192,9 +192,11 @@ def setup_leader_authentication():
             # Default system user. with full access to the cluster.
             setup_basic_auth(username='admin', groups='system:masters',
                              password=token_generator(32, 'admintoken'),
-                             userid='admin')
+                             user='admin')
         # Generate the default service account token key
         os.makedirs('/root/cdk', exist_ok=True)
+        if not os.path.isfile(known_tokens):
+            touch(known_tokens)
         if not os.path.isfile(service_key):
             cmd = ['openssl', 'genrsa', '-out', service_key,
                    '2048']
@@ -958,3 +960,10 @@ def apiserverVersion():
     cmd = 'kube-apiserver --version'.split()
     version_string = check_output(cmd).decode('utf-8')
     return tuple(int(q) for q in re.findall("[0-9]+", version_string)[:3])
+
+
+def touch(fname):
+    try:
+        os.utime(fname, None)
+    except OSError:
+        open(fname, 'a').close()

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -790,6 +790,7 @@ def configure_master_services():
     api_opts.add('insecure-bind-address', '127.0.0.1')
     api_opts.add('insecure-port', '8080')
     api_opts.add('storage-backend', 'etcd2')  # FIXME: add etcd3 support
+    api_opts.add('authorization-mode', hookenv.config('authorization-mode'))
     admission_control = [
         'NamespaceLifecycle',
         'LimitRanger',

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -357,7 +357,7 @@ def create_service_configs(kube_control):
     setup_tokens(kubelet_token, user, userid, "system:nodes")
     proxy_token = get_token('kube-proxy')
     if not proxy_token:
-        setup_tokens(None, 'kube-proxy', 'kube-proxy', "kube-proxy")
+        setup_tokens(None, 'system:kube-proxy', 'kube-proxy', "kube-proxy")
         proxy_token = get_token('kube-proxy')
 
     # Send the data

--- a/cluster/juju/layers/kubernetes-master/templates/default-rbac-roles.yaml
+++ b/cluster/juju/layers/kubernetes-master/templates/default-rbac-roles.yaml
@@ -1,0 +1,39 @@
+# Full read access to the api and resources
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-reader
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+# Wide open access to the cluster (mostly for kubelet)
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-writer
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+# Give admin, kubelet, kube-system, kube-proxy god access
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-write
+subjects:
+  - kind: User
+    name: admin
+  - kind: User
+    name: kubelet
+  - kind: ServiceAccount
+    name: default
+    namespace: kube-system
+  - kind: User
+    name: kube-proxy
+roleRef:
+  kind: ClusterRole
+  name: cluster-writer
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/flagmanager.py
+++ b/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/flagmanager.py
@@ -84,7 +84,7 @@ class FlagManager:
 
     def remove(self, key, value):
         '''
-        Remove a flag value from the DockerOpts manager
+        Remove a flag value from the flag manager
         Assuming the data is currently {'foo': ['bar', 'baz']}
         d.remove('foo', 'bar')
         > {'foo': ['baz']}
@@ -98,7 +98,7 @@ class FlagManager:
         '''
         Destructively remove all values and key from the FlagManager
         Assuming the data is currently {'foo': ['bar', 'baz']}
-        d.wipe('foo')
+        d.destroy('foo')
         >{}
         :params key:
         :params strict:

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -761,6 +761,15 @@ def notify_master_gpu_not_enabled(kube_control):
     kube_control.set_gpu(False)
 
 
+@when('kube-control.connected')
+def request_kubelet_and_proxy_credentials(kube_control):
+    """ Request kubelet node authorization with a well formed kubelet user.
+    This also implies that we are requesting kube-proxy auth. """
+
+    nodeuser = 'system:node:{}'.format(gethostname())
+    kube_control.set_auth_request(nodeuser)
+
+
 @when_not('kube-control.connected')
 def missing_kube_control():
     """Inform the operator they need to add the kube-control relation.

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -770,6 +770,14 @@ def request_kubelet_and_proxy_credentials(kube_control):
     kube_control.set_auth_request(nodeuser)
 
 
+@when('kube-control.auth.available')
+def render_service_auth_templates(kube_control):
+    """Render the authentication templates for kubelet and kube-proxy.
+
+    """
+    pass
+
+
 @when_not('kube-control.connected')
 def missing_kube_control():
     """Inform the operator they need to add the kube-control relation.


### PR DESCRIPTION
Insert my Authentication work to enable token/user-pass auth in places for service components as well as the user.

This deprecates the x509 validation of TLS certs for cluster authentication, which is the precursor to authorization via RBAC, which is now enabled by default.

Kubeconfig's have been changed among the services which now live in `/root/cdk/$COMPONENTconfig ` and are not generated until the kube-control interface has been established between the worker/master.

