### PR TITLE
Ensure the client credentials are fixed post upgrade

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -91,14 +91,20 @@ def purge_default_ns_ingress():
         return
 
     if not raw.startswith(b'No resources'):
-        hookenv.log('Removing default namespace nginx-ingress-controller')
-        niccmd = ['kubectl', '--kubeconfig', kubeconfig_path, 'delete',
-                  'rc', 'nginx-ingress-controller']
-        check_call(niccmd)
-        dhbcmd = ['kubectl', '--kubeconfig', kubeconfig_path, 'delete',
-                  'rc', 'default-http-backend']
-        check_call(dhbcmd)
-        set_state('ingress.migrated')
+        try:
+            hookenv.log('Removing default namespace nginx-ingress-controller')
+            niccmd = ['kubectl', '--kubeconfig', kubeconfig_path, 'delete',
+                      'rc', 'nginx-ingress-controller']
+            check_call(niccmd)
+            dhbcmd = ['kubectl', '--kubeconfig', kubeconfig_path, 'delete',
+                      'rc', 'default-http-backend']
+            check_call(dhbcmd)
+            set_state('ingress.migrated')
+        except CalledProcessError:
+            cleanupdm = 'juju run --application kubernetes-worker ' \
+                    ' charms.reactive set_state ingress.migrated'
+            hookenv.log('Error invoking default ingress removal.')
+            hookenv.log('Stop this log spam with {}'.format(cleanupdm))
 
 
 def check_resources_for_upgrade_needed():


### PR DESCRIPTION
During the upgrade sequence, the servers never changed which left the
client credentials in a weird limbo of still having the client keys and
thus did not perform as expected.

This refactoring removes the state check and just overwrites the config
when any scenario is encountered to render the template. I think this
method is fine so long as we are judiciuos in ensuring that we're not in
an infinite loop.