### PR TITLE
Correct missing parameters

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -687,7 +687,7 @@ def build_kubeconfig(server):
     ca_exists = ca and os.path.isfile(ca)
     key = layer_options.get('client_key_path')
     cert = layer_options.get('client_certificate_path')
-    auth_token = get_password('basic_auth.csv')
+    auth_token = get_password('basic_auth.csv', 'admin')
     # Do we have everything we need?
     if ca_exists and auth_token:
         # Create an absolute path for the kubeconfig file.

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -306,7 +306,7 @@ def watch_for_changes(kube_api, kube_control, cni):
       'tls_client.server.key.saved',
       'kube-control.dns.available', 'kube-control.auth.available',
       'cni.available', 'kubernetes-worker.restart-needed')
-def start_worker(kube_api, kube_control, cni):
+def start_worker(kube_api, kube_control, auth_control, cni):
     ''' Start kubelet using the provided API and DNS info.'''
     servers = get_kube_api_servers(kube_api)
     # Note that the DNS server doesn't necessarily exist at this point. We know


### PR DESCRIPTION
Adds a missing parameter to start_worker which was introduced with the
kube-control.auth state, and scope the request for the user credentials
osn master to the 'admin' user, which is a required parameter.