### PR TITLE
Set kubelet dynamic-config-dir on Kubernetes 1.11+

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -749,6 +749,9 @@ def configure_kubelet(dns, ingress_ip):
         if is_state('kubernetes-worker.gpu.enabled'):
             kubelet_opts['feature-gates'] = 'DevicePlugins=true'
 
+    if get_version('kubelet') >= (1, 11):
+        kubelet_opts['dynamic-config-dir'] = '/root/cdk/kubelet/dynamic-config'
+
     configure_kubernetes_service('kubelet', kubelet_opts, 'kubelet-extra-args')
 
 


### PR DESCRIPTION
~~WAIT! This includes and extends https://github.com/juju-solutions/kubernetes/pull/143. Please review that first.~~

~~Depends on https://github.com/juju-solutions/release/pull/27.~~

This makes Dynamic Kubelet Config work.