### PR TITLE
Fix kubernetes-master non-leaders stuck on "Waiting to retry addon deployment"

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -530,7 +530,7 @@ def set_final_status():
 
     components_started = is_state('kubernetes-master.components.started')
     addons_configured = is_state('cdk-addons.configured')
-    if components_started and not addons_configured:
+    if is_leader and components_started and not addons_configured:
         hookenv.status_set('waiting', 'Waiting to retry addon deployment')
         return
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -28,7 +28,6 @@ import ipaddress
 from charms.leadership import leader_get, leader_set
 
 from shutil import move
-from tempfile import TemporaryDirectory
 
 from pathlib import Path
 from shlex import split


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/juju-solutions/kubernetes/commit/bc3e25146f68c3f97ce9e2198831e4a0af1e47ff#diff-e6f5b987d0e976d7b76acd341abc74c0R670, which made it where only the leader runs `configure_cdk_addons`. For non-leaders, this means the `cdk-addons.configured` state never gets set, which causes the `Waiting to retry addon deployment` status to show forever.

This PR fixes that by preventing non-leaders from ever showing the `Waiting to retry addon deployment` status.