### PR TITLE
add endpoint CA certificate handling

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1794,6 +1794,10 @@ def _cloud_config_path(component):
     return _snap_common_path(component) / 'cloud-config.conf'
 
 
+def _cloud_endpoint_ca_path(component):
+    return _snap_common_path(component) / 'cloud-endpoint-ca.crt'
+
+
 def _gcp_creds_path(component):
     return _snap_common_path(component) / 'gcp-creds.json'
 
@@ -1840,14 +1844,22 @@ def _write_openstack_snap_config(component):
     openstack = endpoint_from_flag('endpoint.openstack.ready')
 
     cloud_config_path = _cloud_config_path(component)
-    cloud_config_path.write_text('\n'.join([
+    lines = [
         '[Global]',
         'auth-url = {}'.format(openstack.auth_url),
         'username = {}'.format(openstack.username),
         'password = {}'.format(openstack.password),
         'tenant-name = {}'.format(openstack.project_name),
         'domain-name = {}'.format(openstack.user_domain_name),
-    ]))
+    ]
+    if openstack.endpoint_tls_ca:
+        cloud_endpoint_ca_path = _cloud_endpoint_ca_path(component)
+        cloud_endpoint_ca_path.write_text(base64.b64decode(
+            openstack.endpoint_tls_ca
+        ).decode('utf-8'))
+        lines.append('ca-file = {}'.format(str(cloud_endpoint_ca_path)))
+
+    cloud_config_path.write_text('\n'.join(lines))
 
 
 def _write_vsphere_snap_config(component):

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import hashlib
 import json
 import os
@@ -1426,6 +1427,10 @@ def _cloud_config_path(component):
     return _snap_common_path(component) / 'cloud-config.conf'
 
 
+def _cloud_endpoint_ca_path(component):
+    return _snap_common_path(component) / 'cloud-endpoint-ca.crt'
+
+
 def _gcp_creds_path(component):
     return _snap_common_path(component) / 'gcp-creds.json'
 
@@ -1468,14 +1473,22 @@ def _write_openstack_snap_config(component):
     openstack = endpoint_from_flag('endpoint.openstack.ready')
 
     cloud_config_path = _cloud_config_path(component)
-    cloud_config_path.write_text('\n'.join([
+    lines = [
         '[Global]',
         'auth-url = {}'.format(openstack.auth_url),
         'username = {}'.format(openstack.username),
         'password = {}'.format(openstack.password),
         'tenant-name = {}'.format(openstack.project_name),
         'domain-name = {}'.format(openstack.user_domain_name),
-    ]))
+    ]
+    if openstack.endpoint_tls_ca:
+        cloud_endpoint_ca_path = _cloud_endpoint_ca_path(component)
+        cloud_endpoint_ca_path.write_text(base64.b64decode(
+            openstack.endpoint_tls_ca
+        ).decode('utf-8'))
+        lines.append('ca-file = {}'.format(str(cloud_endpoint_ca_path)))
+
+    cloud_config_path.write_text('\n'.join(lines))
 
 
 def _write_azure_snap_config(component):


### PR DESCRIPTION
OpenStack clouds often have TLS termination with certs signed by
non-public CAs which cannot be verified with a standard set of CA certs
shipped in the core snap used by other snaps.

There is a way to provide a path to a ca-file in cloud.conf for k8s
in-tree OpenStack provider code which relies on gophercloud to use
that cert when creating an HTTP client for o7k endpoint communication.

The content of the CA certificate has to come from the integrator charm
which is not a subordinate, therefore, it must expose that cert over
a relation with other charms consuming data required to render
cloud.conf.