### PR TITLE
Increase default proxy_read_timeout

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/config.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/config.yaml
@@ -11,5 +11,5 @@ options:
       created for the load balancers.
   proxy_read_timeout:
     type: int
-    default: 90
+    default: 600
     description: Timeout in seconds for reading a response from proxy server.


### PR DESCRIPTION
Addresses https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/650

**Release note**:
```release-note
Juju: Increase default kubeapi-load-balancer proxy_read_timeout to 10 minutes.
```
