### PR TITLE
Making master services always restart

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -26,7 +26,7 @@ import ipaddress
 
 from charms.leadership import leader_get, leader_set
 
-from shutil import move
+from shutil import move, copyfile
 from pathlib import Path
 from subprocess import check_call
 from subprocess import check_output
@@ -79,6 +79,12 @@ nrpe.Check.shortname_re = '[\.A-Za-z0-9-_]+$'
 
 snap_resources = ['kubectl', 'kube-apiserver', 'kube-controller-manager',
                   'kube-scheduler', 'cdk-addons', 'kube-proxy']
+
+master_services = ['kube-apiserver',
+                   'kube-controller-manager',
+                   'kube-scheduler',
+                   'kube-proxy']
+
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 db = unitdata.kv()
@@ -204,10 +210,10 @@ def migrate_from_pre_snaps():
     remove_state('kubernetes-master.app_version.set')
 
     # disable old services
-    services = ['kube-apiserver',
-                'kube-controller-manager',
-                'kube-scheduler']
-    for service in services:
+    pre_snap_services = ['kube-apiserver',
+                         'kube-controller-manager',
+                         'kube-scheduler']
+    for service in pre_snap_services:
         service_stop(service)
 
     # rename auth files
@@ -530,16 +536,22 @@ def master_services_down():
     """Ensure master services are up and running.
 
     Return: list of failing services"""
-    services = ['kube-apiserver',
-                'kube-controller-manager',
-                'kube-scheduler',
-                'kube-proxy']
     failing_services = []
-    for service in services:
+    for service in master_services:
         daemon = 'snap.{}.daemon'.format(service)
         if not host.service_running(daemon):
             failing_services.append(service)
     return failing_services
+
+
+def add_systemd_restart_always():
+    for service in master_services:
+        dest_dir = '/etc/systemd/system/snap.{}.daemon.service.d' \
+            .format(service)
+        os.makedirs(dest_dir, exist_ok=True)
+        copyfile('templates/service-always-restart.conf',
+                 '{}/always-restart.conf'.format(dest_dir))
+    check_call(['systemctl', 'daemon-reload'])
 
 
 @when('etcd.available', 'tls_client.server.certificate.saved',
@@ -569,6 +581,9 @@ def start_master():
     configure_apiserver(etcd.get_connection_string())
     configure_controller_manager()
     configure_scheduler()
+
+    # make all services restart all the time
+    add_systemd_restart_always()
 
     # kube-proxy
     cni = endpoint_from_flag('cni.available')
@@ -945,6 +960,7 @@ def update_nrpe_config(unused=None):
     current_unit = nrpe.get_nagios_unit_name()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
     nrpe.add_init_service_checks(nrpe_setup, services, current_unit)
+    nrpe.add_init_service_checks(nrpe_setup, master_services, current_unit)
     nrpe_setup.write()
 
 
@@ -1060,10 +1076,8 @@ def shutdown():
     """ Stop the kubernetes master services
 
     """
-    service_stop('snap.kube-apiserver.daemon')
-    service_stop('snap.kube-controller-manager.daemon')
-    service_stop('snap.kube-scheduler.daemon')
-    service_stop('snap.kube-proxy.daemon')
+    for service in master_services:
+        service_stop(service)
 
 
 def build_kubeconfig(server):

--- a/cluster/juju/layers/kubernetes-master/templates/service-always-restart.conf
+++ b/cluster/juju/layers/kubernetes-master/templates/service-always-restart.conf
@@ -1,0 +1,3 @@
+[Service]
+Restart=Always
+RestartSec=15


### PR DESCRIPTION
should port this to worker as well

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Juju master node services will now restart forever in case of failure.
```
