### PR TITLE
Update Juju charms to deploy 1.12 by default

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/config.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "1.11/stable"
+    default: "1.12/stable"
     description: |
       Snap channel to install Kubernetes snaps from

--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -89,7 +89,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.11/stable"
+    default: "1.12/stable"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -23,7 +23,7 @@ options:
       policies (PSP) should be used to restrict container privileges.
   channel:
     type: string
-    default: "1.11/stable"
+    default: "1.12/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
Please note that 1.12/stable is currently empty - we still need to promote 1.12.0 there.