### PR TITLE
Fix status when cni is not ready

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -501,6 +501,16 @@ def set_final_status():
             msg = 'Stopped services: {}'.format(','.join(failing_services))
             hookenv.status_set('blocked', msg)
             return
+    else:
+        # if we don't have components starting, we're waiting for that and
+        # shouldn't fall through to Kubernetes master running.
+        if (is_state('cni.available')):
+            hookenv.status_set('blocked',
+                               'Waiting for master components to start')
+        else:
+            hookenv.status_set('blocked',
+                               'Waiting for CNI plugins to become available')
+        return
 
     is_leader = is_state('leadership.is_leader')
     authentication_setup = is_state('authentication.setup')

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -512,15 +512,16 @@ def set_final_status():
                                'Waiting for CNI plugins to become available')
         return
 
+    # Note that after this point, kubernetes-master.components.started is always
+    # True.
     is_leader = is_state('leadership.is_leader')
     authentication_setup = is_state('authentication.setup')
     if not is_leader and not authentication_setup:
         hookenv.status_set('waiting', 'Waiting on leaders crypto keys.')
         return
 
-    components_started = is_state('kubernetes-master.components.started')
     addons_configured = is_state('cdk-addons.configured')
-    if is_leader and components_started and not addons_configured:
+    if is_leader and not addons_configured:
         hookenv.status_set('waiting', 'Waiting to retry addon deployment')
         return
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -505,7 +505,7 @@ def set_final_status():
         # if we don't have components starting, we're waiting for that and
         # shouldn't fall through to Kubernetes master running.
         if (is_state('cni.available')):
-            hookenv.status_set('waiting',
+            hookenv.status_set('maintenance',
                                'Waiting for master components to start')
         else:
             hookenv.status_set('waiting',

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -505,10 +505,10 @@ def set_final_status():
         # if we don't have components starting, we're waiting for that and
         # shouldn't fall through to Kubernetes master running.
         if (is_state('cni.available')):
-            hookenv.status_set('blocked',
+            hookenv.status_set('waiting',
                                'Waiting for master components to start')
         else:
-            hookenv.status_set('blocked',
+            hookenv.status_set('waiting',
                                'Waiting for CNI plugins to become available')
         return
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/666
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed juju status incorrectly reporting ready status in a rare situation where CNI was not ready.
```
