### PR TITLE
CNI on the master doesn't work on the master if it requires kubeconfig

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -306,7 +306,11 @@ def storage_backend_changed():
 def configure_cni(cni):
     ''' Set master configuration on the CNI relation. This lets the CNI
     subordinate know that we're the master so it can respond accordingly. '''
-    cni.set_config(is_master=True, kubeconfig_path='')
+    # not sure how I feel about using kubeclientconfig here. Should we
+    # generate a new config just for master cni? We use the kubelet config
+    # on the worker, which may become available here if we ever support
+    # workloads on the master units.
+    cni.set_config(is_master=True, kubeconfig_path=kubeclientconfig_path)
 
 
 @when('leadership.is_leader')
@@ -1109,7 +1113,7 @@ def build_kubeconfig(server):
     client_pass = get_password('basic_auth.csv', 'admin')
     # Do we have everything we need?
     if ca_exists and client_pass:
-        # Create an absolute path for the kubeconfig file.
+        # Create an absolute path for the client kubeconfig file.
         kubeconfig_path = os.path.join(os.sep, 'home', 'ubuntu', 'config')
         # Create the kubeconfig on this system so users can access the cluster.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We were passing an empty string for the config. Calico is known to use this. This means that Calico and things that rely on kube-proxy on the master such as Keystone integration won't work without this change.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed kube-proxy on the master node with CNI such as calico
```
