### PR TITLE
Reverting nginx 1.12 changes until https://github.com/kubernetes/kube…

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -101,7 +101,7 @@ def upgrade_charm():
 
     # Remove the RC for nginx ingress if it exists
     if hookenv.config().get('ingress'):
-        set_state('kubernetes-worker.remove-old-ingress')
+        kubectl_success('delete', 'rc', 'nginx-ingress-controller')
 
     # Remove gpu.enabled state so we can reconfigure gpu-related kubelet flags,
     # since they can differ between k8s versions
@@ -119,35 +119,6 @@ def upgrade_charm():
     remove_state('kubernetes-worker.ingress.available')
     remove_state('worker.auth.bootstrapped')
     set_state('kubernetes-worker.restart-needed')
-
-
-@when('kubernetes-worker.remove-old-ingress')
-def remove_old_ingress():
-    try:
-        kubectl('delete', 'rc', 'nginx-ingress-controller',
-                '--ignore-not-found')
-
-        # these moved into a different namespace for 1.12
-        kubectl('delete', 'rc', 'default-http-backend',
-                '--ignore-not-found')
-        kubectl('delete', 'svc', 'default-http-backend',
-                '--ignore-not-found')
-        kubectl('delete', 'ds', 'nginx-ingress-{}-controller'.format(
-                    hookenv.service_name()), '--ignore-not-found')
-        kubectl('delete', 'serviceaccount',
-                'nginx-ingress-{}-serviceaccount'.format(
-                    hookenv.service_name()), '--ignore-not-found')
-        kubectl('delete', 'clusterrolebinding',
-                'nginx-ingress-clusterrole-nisa-{}-binding'.format(
-                    hookenv.service_name()), '--ignore-not-found')
-        kubectl('delete', 'configmap',
-                'nginx-load-balancer-{}-conf'.format(
-                    hookenv.service_name()), '--ignore-not-found')
-    except CalledProcessError:
-        # try again next time
-        return
-
-    remove_state('kubernetes-worker.remove-old-ingress')
 
 
 def set_upgrade_needed():
@@ -824,7 +795,6 @@ def launch_default_ingress_controller():
     context = {}
     context['arch'] = arch()
     addon_path = '/root/cdk/addons/{}'
-    context['juju_application'] = hookenv.service_name()
 
     context['defaultbackend_image'] = config.get('default-backend-image')
     if (context['defaultbackend_image'] == "" or
@@ -839,35 +809,7 @@ def launch_default_ingress_controller():
             context['defaultbackend_image'] = \
                 "k8s.gcr.io/defaultbackend-amd64:1.5"
 
-    # Render the ingress daemon set controller manifest
-    context['ssl_chain_completion'] = config.get(
-        'ingress-ssl-chain-completion')
-    context['ingress_image'] = config.get('nginx-image')
-    if context['ingress_image'] == "" or context['ingress_image'] == "auto":
-        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0',  # noqa
-                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.19.0',  # noqa
-                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.19.0',  # noqa
-                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.19.0',  # noqa
-                  }
-        context['ingress_image'] = images.get(context['arch'], images['amd64'])
-    if get_version('kubelet') < (1, 9):
-        context['daemonset_api_version'] = 'extensions/v1beta1'
-    else:
-        context['daemonset_api_version'] = 'apps/v1beta2'
-    manifest = addon_path.format('ingress-daemon-set.yaml')
-    render('ingress-daemon-set.yaml', manifest, context)
-    hookenv.log('Creating the ingress daemon set.')
-    try:
-        kubectl('apply', '-f', manifest)
-    except CalledProcessError as e:
-        hookenv.log(e)
-        hookenv.log('Failed to create ingress controller. Will attempt again next update.')  # noqa
-        hookenv.close_port(80)
-        hookenv.close_port(443)
-        return
-
     # Render the default http backend (404) replicationcontroller manifest
-    # needs to happen after ingress-daemon-set since that sets up the namespace
     manifest = addon_path.format('default-http-backend.yaml')
     render('default-http-backend.yaml', manifest, context)
     hookenv.log('Creating the default http backend.')
@@ -876,6 +818,34 @@ def launch_default_ingress_controller():
     except CalledProcessError as e:
         hookenv.log(e)
         hookenv.log('Failed to create default-http-backend. Will attempt again next update.')  # noqa
+        hookenv.close_port(80)
+        hookenv.close_port(443)
+        return
+
+    # Render the ingress daemon set controller manifest
+    context['ssl_chain_completion'] = config.get(
+        'ingress-ssl-chain-completion')
+    context['ingress_image'] = config.get('nginx-image')
+    if context['ingress_image'] == "" or context['ingress_image'] == "auto":
+        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.16.1',  # noqa
+                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.16.1',  # noqa
+                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.16.1',  # noqa
+                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.16.1',  # noqa
+                  }
+        context['ingress_image'] = images.get(context['arch'], images['amd64'])
+    if get_version('kubelet') < (1, 9):
+        context['daemonset_api_version'] = 'extensions/v1beta1'
+    else:
+        context['daemonset_api_version'] = 'apps/v1beta2'
+    context['juju_application'] = hookenv.service_name()
+    manifest = addon_path.format('ingress-daemon-set.yaml')
+    render('ingress-daemon-set.yaml', manifest, context)
+    hookenv.log('Creating the ingress daemon set.')
+    try:
+        kubectl('apply', '-f', manifest)
+    except CalledProcessError as e:
+        hookenv.log(e)
+        hookenv.log('Failed to create ingress controller. Will attempt again next update.')  # noqa
         hookenv.close_port(80)
         hookenv.close_port(443)
         return

--- a/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
@@ -1,27 +1,19 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
-  name: default-http-backend-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
-  namespace: ingress-nginx-{{ juju_application }}
+  name: default-http-backend
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      app.kubernetes.io/name: default-http-backend-{{ juju_application }}
-      app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    app: default-http-backend
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: default-http-backend-{{ juju_application }}
-        app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+        app: default-http-backend
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - name: default-http-backend-{{ juju_application }}
+      - name: default-http-backend
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
@@ -34,28 +26,19 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 5
         ports:
-          - containerPort: 8080
-        resources:
-          limits:
-            cpu: 10m
-            memory: 20Mi
-          requests:
-            cpu: 10m
-            memory: 20Mi
+        - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: default-http-backend-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
+  name: default-http-backend
+#  namespace: kube-system
   labels:
-    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+    k8s-app: default-http-backend
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    protocol: TCP
+    targetPort: 80
   selector:
-    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    app: default-http-backend

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
@@ -1,58 +1,12 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: ingress-nginx-{{ juju_application }}
-  labels:
-    cdk-{{ juju_application }}-ingress: "true"
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: nginx-configuration-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: tcp-services-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: udp-services-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nginx-ingress-serviceaccount-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-{{ juju_application }}-serviceaccount
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: nginx-ingress-clusterrole-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-{{ juju_application }}-clusterrole
 rules:
   - apiGroups:
       - ""
@@ -104,11 +58,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: nginx-ingress-role-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-{{ juju_application }}-role
 rules:
   - apiGroups:
       - ""
@@ -144,72 +94,61 @@ rules:
       - endpoints
     verbs:
       - get
+      - create
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: nginx-ingress-role-nisa-binding-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-role-nisa-{{ juju_application }}-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nginx-ingress-role-{{ juju_application }}
+  name: nginx-ingress-{{ juju_application }}-role
 subjects:
   - kind: ServiceAccount
-    name: nginx-ingress-serviceaccount-{{ juju_application }}
-    namespace: ingress-nginx-{{ juju_application }}
+    name: nginx-ingress-{{ juju_application }}-serviceaccount
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: nginx-ingress-clusterrole-nisa-binding-{{ juju_application }}
-  labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
+  name: nginx-ingress-clusterrole-nisa-{{ juju_application }}-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nginx-ingress-clusterrole-{{ juju_application }}
+  name: nginx-ingress-{{ juju_application }}-clusterrole
 subjects:
   - kind: ServiceAccount
-    name: nginx-ingress-serviceaccount-{{ juju_application }}
-    namespace: ingress-nginx-{{ juju_application }}
+    name: nginx-ingress-{{ juju_application }}-serviceaccount
+    namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-load-balancer-{{ juju_application }}-conf
 ---
 apiVersion: {{ daemonset_api_version }}
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-controller-{{ juju_application }}
-  namespace: ingress-nginx-{{ juju_application }}
+  name: nginx-ingress-{{ juju_application }}-controller
   labels:
-    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     juju-application: nginx-ingress-{{ juju_application }}
-    cdk-{{ juju_application }}-ingress: "true"
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-      app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+      name: nginx-ingress-{{ juju_application }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
-        app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
-      annotations:
-        prometheus.io/port: "10254"
-        prometheus.io/scrape: "true"
+        name: nginx-ingress-{{ juju_application }}
     spec:
-      serviceAccountName: nginx-ingress-serviceaccount-{{ juju_application }}
       nodeSelector:
         juju-application: {{ juju_application }}
       terminationGracePeriodSeconds: 60
       # hostPort doesn't work with CNI, so we have to use hostNetwork instead
       # see https://github.com/kubernetes/kubernetes/issues/23920
       hostNetwork: true
+      serviceAccountName: nginx-ingress-{{ juju_application }}-serviceaccount
       containers:
       - image: {{ ingress_image }}
         name: nginx-ingress-{{ juju_application }}
@@ -220,14 +159,6 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
-        securityContext:
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - NET_BIND_SERVICE
-          # www-data -> 33
-          runAsUser: 33
         # use downward API
         env:
           - name: POD_NAME
@@ -239,35 +170,10 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         ports:
-          - name: http
-            containerPort: 80
-          - name: https
-            containerPort: 443
+        - containerPort: 80
+        - containerPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend-{{ juju_application }}
-        - --configmap=$(POD_NAMESPACE)/nginx-configuration
-        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
-        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
-        - --annotations-prefix=nginx.ingress.kubernetes.io
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
         - --enable-ssl-chain-completion={{ ssl_chain_completion }}
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Reverting the nginx bump until https://github.com/kubernetes/kubernetes/issues/70044 is resolved. This bug prevents ingress from coming online after a charm upgrade because the old nginx pods get stuck terminating and hold the ports hostage.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
