### PR TITLE
Add build script for CNI resources

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
+++ b/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CNI_VERSION="${CNI_VERSION:-v0.7.1}"
+ARCH="${ARCH:-amd64 arm64 s390x}"
+
+temp_dir="$(readlink -f build-cni-resources.tmp)"
+rm -rf "$temp_dir"
+mkdir "$temp_dir"
+(cd "$temp_dir"
+  git clone https://github.com/containernetworking/plugins.git cni-plugins \
+    --branch "$CNI_VERSION" \
+    --depth 1
+
+  # Grab the user id and group id of this current user.
+  GROUP_ID=$(id -g)
+  USER_ID=$(id -u)
+
+  for arch in $ARCH; do
+    echo "Building cni $CNI_VERSION for $arch"
+    docker run \
+      --rm \
+      -e GOOS=linux \
+      -e GOARCH="$arch" \
+      -v "$temp_dir"/cni-plugins:/cni \
+      golang \
+      /bin/bash -c "cd /cni && ./build.sh && chown -R ${USER_ID}:${GROUP_ID} /cni"
+
+    (cd cni-plugins/bin
+      tar -caf "$temp_dir/cni-$arch-$CNI_VERSION.tar.gz" .
+    )
+  done
+)
+mv "$temp_dir"/cni-*.tar.gz .
+rm -rf "$temp_dir"

--- a/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
+++ b/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
@@ -34,9 +34,9 @@ mkdir "$temp_dir"
       echo "Built $(date)" >> BUILD_INFO
       echo "build script commit: $build_script_commit" >> BUILD_INFO
       echo "cni-plugins commit: $(git show --oneline -q)" >> BUILD_INFO
-      tar -caf "$temp_dir/cni-$arch-$CNI_VERSION.tar.gz" .
+      tar -czf "$temp_dir/cni-$arch-$CNI_VERSION.tgz" .
     )
   done
 )
-mv "$temp_dir"/cni-*.tar.gz .
+mv "$temp_dir"/cni-*.tgz .
 rm -rf "$temp_dir"

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -227,22 +227,11 @@ def install_cni_plugins():
 
     hookenv.status_set('maintenance', 'Unpacking cni resource.')
 
-    unpack_path = '{}/files/cni'.format(charm_dir)
+    unpack_path = '/opt/cni/bin'
     os.makedirs(unpack_path, exist_ok=True)
     cmd = ['tar', 'xfvz', archive, '-C', unpack_path]
     hookenv.log(cmd)
     check_call(cmd)
-
-    apps = [
-        {'name': 'loopback', 'path': '/opt/cni/bin'}
-    ]
-
-    for app in apps:
-        unpacked = '{}/{}'.format(unpack_path, app['name'])
-        app_path = os.path.join(app['path'], app['name'])
-        install = ['install', '-v', '-D', unpacked, app_path]
-        hookenv.log(install)
-        check_call(install)
 
     # Used by the "registry" action. The action is run on a single worker, but
     # the registry pod can end up on any worker, so we need this directory on


### PR DESCRIPTION
I've ported the original CNI build script over from here: https://github.com/juju-solutions/kubernetes-jenkins/blob/66784fbac643b710d4270d4bfca0819192b83119/resources/build-cni.sh. I think this is a better location for it.

I also changed the charm code to extract _all_ CNI plugins to /opt/cni/bin, not just the loopback one. This will make things simpler for the flannel and canal charms, as they will no longer have to bring their own copies of the core CNI plugins.