### PR TITLE
adjust roles to allow fetching logs with rbac enabled

### DIFF
--- a/cluster/juju/layers/kubernetes-master/README.md
+++ b/cluster/juju/layers/kubernetes-master/README.md
@@ -77,6 +77,15 @@ For more information on the possible values for `snapd_refresh`, see the
 This charm supports some configuration options to set up a Kubernetes cluster
 that works in your environment:
 
+#### authorization-mode
+
+Comma separated authorization modes. For example, enable RBAC and Node
+authorization:
+
+```sh
+juju config kubernetes-master authorization-mode="RBAC,Node"
+```
+
 #### dns_domain
 
 The domain name to use for the Kubernetes cluster for DNS.
@@ -85,10 +94,6 @@ The domain name to use for the Kubernetes cluster for DNS.
 
 Enables the installation of Kubernetes dashboard, Heapster, Grafana, and
 InfluxDB.
-
-#### enable-rbac
-
-Enable RBAC and Node authorisation.
 
 # DNS for the cluster
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1047,21 +1047,21 @@ def switch_auth_mode():
       'kubernetes-master.components.started',
       'kubernetes-master.create.rbac')
 def create_rbac_resources():
-    rbac_metrics_path = '/root/cdk/rbac-metrics.yaml'
+    rbac_proxy_path = '/root/cdk/rbac-proxy.yaml'
 
-    # NB: metrics are scraped by proxy, so the 'user' here is the
+    # NB: when metrics and logs are retrieved by proxy, the 'user' is the
     # common name of the cert used to authenticate the proxied request.
     # The CN for /root/cdk/client.crt is 'client'.
-    metric_user = 'client'
+    proxy_user = 'client'
     context = {'juju_application': hookenv.service_name(),
-               'metric_user': metric_user}
-    render('rbac-metrics.yaml', rbac_metrics_path, context)
+               'proxy_user': proxy_user}
+    render('rbac-proxy.yaml', rbac_proxy_path, context)
 
-    hookenv.log('Creating metric-related RBAC resources.')
-    if kubectl_manifest('apply', rbac_metrics_path):
+    hookenv.log('Creating proxy-related RBAC resources.')
+    if kubectl_manifest('apply', rbac_proxy_path):
         remove_state('kubernetes-master.create.rbac')
     else:
-        msg = 'Failed to apply {}, will retry.'.format(rbac_metrics_path)
+        msg = 'Failed to apply {}, will retry.'.format(rbac_proxy_path)
         hookenv.log(msg)
 
 
@@ -1069,14 +1069,14 @@ def create_rbac_resources():
       'kubernetes-master.components.started',
       'kubernetes-master.remove.rbac')
 def remove_rbac_resources():
-    rbac_metrics_path = '/root/cdk/rbac-metrics.yaml'
-    if os.path.isfile(rbac_metrics_path):
-        hookenv.log('Removing metric-related RBAC resources.')
-        if kubectl_manifest('delete', rbac_metrics_path):
-            os.remove(rbac_metrics_path)
+    rbac_proxy_path = '/root/cdk/rbac-proxy.yaml'
+    if os.path.isfile(rbac_proxy_path):
+        hookenv.log('Removing proxy-related RBAC resources.')
+        if kubectl_manifest('delete', rbac_proxy_path):
+            os.remove(rbac_proxy_path)
             remove_state('kubernetes-master.remove.rbac')
         else:
-            msg = 'Failed to delete {}, will retry.'.format(rbac_metrics_path)
+            msg = 'Failed to delete {}, will retry.'.format(rbac_proxy_path)
             hookenv.log(msg)
     else:
         # if we dont have the yaml, there's nothing for us to do

--- a/cluster/juju/layers/kubernetes-master/templates/rbac-proxy.yaml
+++ b/cluster/juju/layers/kubernetes-master/templates/rbac-proxy.yaml
@@ -1,21 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-clusterrole-{{ juju_application }}
+  name: proxy-clusterrole-{{ juju_application }}
 rules:
 - apiGroups: [""]
-  resources: ["nodes/metrics"]
-  verbs: ["get"]
+  resources:
+  - nodes/metrics
+  - nodes/proxy
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-role-binding-{{ juju_application }}
+  name: proxy-role-binding-{{ juju_application }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-clusterrole-{{ juju_application }}
+  name: proxy-clusterrole-{{ juju_application }}
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
-  name: {{ metric_user }}
+  name: {{ proxy_user }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The previous rbac resources were created with metrics in mind, but it's more
accurate to consider them 'proxy' resources. Recall that we want to allow
our 'client' proxy user access to things like metrics and logs. To that end,
this:

- fixes the rbac config in the readme
- renames `rbac-metrics` to the more appropriate `rbac-proxy`
- adds the 'nodes/proxy' resource and relevant verbs needed to access logs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/642

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
