### PR TITLE
Added an error message when using an unsupported version of Keystone

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -496,6 +496,12 @@ def set_final_status():
         hookenv.status_set(status, 'Waiting for workers.')
         return
 
+    ks = endpoint_from_flag('keystone-credentials.available.auth')
+    if ks and ks.api_version() == '2':
+        msg = 'Keystone auth v2 detected. v3 is required.'
+        hookenv.status_set(status, msg)
+        return
+
     upgrade_needed = is_state('kubernetes-master.upgrade-needed')
     upgrade_specified = is_state('kubernetes-master.upgrade-specified')
     if upgrade_needed and not upgrade_specified:
@@ -1429,6 +1435,17 @@ def configure_apiserver(etcd_connection_string):
         elif is_state('leadership.set.keystone-cdk-addons-configured'):
             hookenv.log('Unable to find keystone endpoint. Will retry')
         remove_state('keystone.apiserver.configured')
+        # Note that we can get into a nasty state here
+        # if the user has specified webhook and they're relying on
+        # keystone auth to handle that, the api server will fail to start
+        # because we push it Webhook and no webhook config. We can't generate
+        # the config because we can't talk to the apiserver to get the ip of
+        # the service to put into the webhook template. A chicken and egg
+        # problem. To fix this, remove Webhook if keystone is related and
+        # trying to come up until we can find the service IP.
+        if 'Webhook' in auth_mode:
+            auth_mode = ','.join([i for i in auth_mode.split(',')
+                                  if i != 'Webhook'])
 
     api_opts['authorization-mode'] = auth_mode
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -499,7 +499,7 @@ def set_final_status():
     ks = endpoint_from_flag('keystone-credentials.available.auth')
     if ks and ks.api_version() == '2':
         msg = 'Keystone auth v2 detected. v3 is required.'
-        hookenv.status_set(status, msg)
+        hookenv.status_set('blocked', msg)
         return
 
     upgrade_needed = is_state('kubernetes-master.upgrade-needed')
@@ -1432,20 +1432,21 @@ def configure_apiserver(etcd_connection_string):
         if ks and not ks_ip:
             hookenv.log('Unable to find k8s-keystone-auth-service '
                         'service. Will retry')
+            # Note that we can get into a nasty state here
+            # if the user has specified webhook and they're relying on
+            # keystone auth to handle that, the api server will fail to start
+            # because we push it Webhook and no webhook config. We can't
+            # generate the config because we can't talk to the apiserver to
+            # get the ip of the service to put into the webhook template. A
+            # chicken and egg problem. To fix this, remove Webhook if keystone
+            # is related and trying to come up until we can find the
+            # service IP.
+            if 'Webhook' in auth_mode:
+                auth_mode = ','.join([i for i in auth_mode.split(',')
+                                      if i != 'Webhook'])
         elif is_state('leadership.set.keystone-cdk-addons-configured'):
             hookenv.log('Unable to find keystone endpoint. Will retry')
         remove_state('keystone.apiserver.configured')
-        # Note that we can get into a nasty state here
-        # if the user has specified webhook and they're relying on
-        # keystone auth to handle that, the api server will fail to start
-        # because we push it Webhook and no webhook config. We can't generate
-        # the config because we can't talk to the apiserver to get the ip of
-        # the service to put into the webhook template. A chicken and egg
-        # problem. To fix this, remove Webhook if keystone is related and
-        # trying to come up until we can find the service IP.
-        if 'Webhook' in auth_mode:
-            auth_mode = ','.join([i for i in auth_mode.split(',')
-                                  if i != 'Webhook'])
 
     api_opts['authorization-mode'] = auth_mode
 

--- a/cluster/juju/layers/kubernetes-master/templates/kube-keystone.sh
+++ b/cluster/juju/layers/kubernetes-master/templates/kube-keystone.sh
@@ -36,7 +36,7 @@ get_keystone_token() {
   if [ -z "$token" ]; then
     echo "Invalid authentication information"
   else
-    echo $(echo ${token} | awk -F ': ' '{print $2}')
+    echo $(echo ${token} | awk -F ': ' '{print $2}' | sed -e 's/[[:space:]]*$//')
   fi
 }
 echo "Function get_keystone_token created. Type get_keystone_token in order to generate a login token for the Kubernetes dashboard."


### PR DESCRIPTION
Changed kube-keystone script to strip trailing whitespace as new key method returns it
Fixed potential issue with adding Webhook auth before we have the Keystone service IP resulting in a deadlock

/kind bug

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
NONE
```
