### PR TITLE
Updating nginx to 1.13 version

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -70,6 +70,11 @@ options:
       to attempt auto-retrieval of intermediate certificates.  The default
       (false) is recommended for all production kubernetes installations, and
       any environment which does not have outbound Internet access.
+  ingress-num-replicas:
+    type: string
+    default: "1"
+    description: |
+      Number of replicas used for ingress. Increase to handle more ingress traffic.
   nginx-image:
     type: string
     default: "auto"

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -101,7 +101,7 @@ def upgrade_charm():
 
     # Remove the RC for nginx ingress if it exists
     if hookenv.config().get('ingress'):
-        kubectl_success('delete', 'rc', 'nginx-ingress-controller')
+        set_state('kubernetes-worker.remove-old-ingress')
 
     # Remove gpu.enabled state so we can reconfigure gpu-related kubelet flags,
     # since they can differ between k8s versions
@@ -119,6 +119,35 @@ def upgrade_charm():
     remove_state('kubernetes-worker.ingress.available')
     remove_state('worker.auth.bootstrapped')
     set_state('kubernetes-worker.restart-needed')
+
+
+@when('kubernetes-worker.remove-old-ingress')
+def remove_old_ingress():
+    try:
+        kubectl('delete', 'rc', 'nginx-ingress-controller',
+                '--ignore-not-found')
+
+        # these moved into a different namespace for 1.12
+        kubectl('delete', 'rc', 'default-http-backend',
+                '--ignore-not-found')
+        kubectl('delete', 'svc', 'default-http-backend',
+                '--ignore-not-found')
+        kubectl('delete', 'ds', 'nginx-ingress-{}-controller'.format(
+                    hookenv.service_name()), '--ignore-not-found')
+        kubectl('delete', 'serviceaccount',
+                'nginx-ingress-{}-serviceaccount'.format(
+                    hookenv.service_name()), '--ignore-not-found')
+        kubectl('delete', 'clusterrolebinding',
+                'nginx-ingress-clusterrole-nisa-{}-binding'.format(
+                    hookenv.service_name()), '--ignore-not-found')
+        kubectl('delete', 'configmap',
+                'nginx-load-balancer-{}-conf'.format(
+                    hookenv.service_name()), '--ignore-not-found')
+    except CalledProcessError:
+        # try again next time
+        return
+
+    remove_state('kubernetes-worker.remove-old-ingress')
 
 
 def set_upgrade_needed():
@@ -784,6 +813,7 @@ def launch_default_ingress_controller():
     context = {}
     context['arch'] = arch()
     addon_path = '/root/cdk/addons/{}'
+    context['juju_application'] = hookenv.service_name()
 
     context['defaultbackend_image'] = config.get('default-backend-image')
     if (context['defaultbackend_image'] == "" or
@@ -798,35 +828,21 @@ def launch_default_ingress_controller():
             context['defaultbackend_image'] = \
                 "k8s.gcr.io/defaultbackend-amd64:1.5"
 
-    # Render the default http backend (404) replicationcontroller manifest
-    manifest = addon_path.format('default-http-backend.yaml')
-    render('default-http-backend.yaml', manifest, context)
-    hookenv.log('Creating the default http backend.')
-    try:
-        kubectl('apply', '-f', manifest)
-    except CalledProcessError as e:
-        hookenv.log(e)
-        hookenv.log('Failed to create default-http-backend. Will attempt again next update.')  # noqa
-        hookenv.close_port(80)
-        hookenv.close_port(443)
-        return
-
     # Render the ingress daemon set controller manifest
     context['ssl_chain_completion'] = config.get(
         'ingress-ssl-chain-completion')
     context['ingress_image'] = config.get('nginx-image')
     if context['ingress_image'] == "" or context['ingress_image'] == "auto":
-        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.16.1',  # noqa
-                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.16.1',  # noqa
-                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.16.1',  # noqa
-                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.16.1',  # noqa
+        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0',  # noqa
+                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.19.0',  # noqa
+                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.19.0',  # noqa
+                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.19.0',  # noqa
                   }
         context['ingress_image'] = images.get(context['arch'], images['amd64'])
     if get_version('kubelet') < (1, 9):
         context['daemonset_api_version'] = 'extensions/v1beta1'
     else:
         context['daemonset_api_version'] = 'apps/v1beta2'
-    context['juju_application'] = hookenv.service_name()
     manifest = addon_path.format('ingress-daemon-set.yaml')
     render('ingress-daemon-set.yaml', manifest, context)
     hookenv.log('Creating the ingress daemon set.')
@@ -835,6 +851,20 @@ def launch_default_ingress_controller():
     except CalledProcessError as e:
         hookenv.log(e)
         hookenv.log('Failed to create ingress controller. Will attempt again next update.')  # noqa
+        hookenv.close_port(80)
+        hookenv.close_port(443)
+        return
+
+    # Render the default http backend (404) replicationcontroller manifest
+    # needs to happen after ingress-daemon-set since that sets up the namespace
+    manifest = addon_path.format('default-http-backend.yaml')
+    render('default-http-backend.yaml', manifest, context)
+    hookenv.log('Creating the default http backend.')
+    try:
+        kubectl('apply', '-f', manifest)
+    except CalledProcessError as e:
+        hookenv.log(e)
+        hookenv.log('Failed to create default-http-backend. Will attempt again next update.')  # noqa
         hookenv.close_port(80)
         hookenv.close_port(443)
         return

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -528,7 +528,7 @@ def sdn_changed():
 @when('kubernetes-worker.config.created')
 @when_not('kubernetes-worker.ingress.available')
 def render_and_launch_ingress():
-    ''' If configuration has ingress daemon set enabled, launch the ingress
+    ''' If configuration has ingress deployment enabled, launch the ingress
     load balancer and default http backend. Otherwise attempt deletion. '''
     config = hookenv.config()
     # If ingress is enabled, launch the ingress controller
@@ -539,7 +539,7 @@ def render_and_launch_ingress():
         kubectl_manifest('delete',
                          '/root/cdk/addons/default-http-backend.yaml')
         kubectl_manifest('delete',
-                         '/root/cdk/addons/ingress-daemon-set.yaml')  # noqa
+                         '/root/cdk/addons/ingress-deployment.yaml')  # noqa
         hookenv.close_port(80)
         hookenv.close_port(443)
 
@@ -799,7 +799,8 @@ def configure_kubelet(dns, ingress_ip):
 
 @when_any('config.changed.default-backend-image',
           'config.changed.ingress-ssl-chain-completion',
-          'config.changed.nginx-image')
+          'config.changed.nginx-image',
+          'config.changed.ingress-num-replicas')
 @when('kubernetes-worker.config.created')
 def launch_default_ingress_controller():
     ''' Launch the Kubernetes ingress controller & default backend (404) '''
@@ -828,24 +829,21 @@ def launch_default_ingress_controller():
             context['defaultbackend_image'] = \
                 "k8s.gcr.io/defaultbackend-amd64:1.5"
 
-    # Render the ingress daemon set controller manifest
+    # Render the ingress deployment controller manifest
     context['ssl_chain_completion'] = config.get(
         'ingress-ssl-chain-completion')
     context['ingress_image'] = config.get('nginx-image')
     if context['ingress_image'] == "" or context['ingress_image'] == "auto":
-        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0',  # noqa
-                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.19.0',  # noqa
-                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.19.0',  # noqa
-                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.19.0',  # noqa
+        images = {'amd64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.21.0',  # noqa
+                  'arm64': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-arm64:0.21.0',  # noqa
+                  's390x': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-s390x:0.21.0',  # noqa
+                  'ppc64el': 'quay.io/kubernetes-ingress-controller/nginx-ingress-controller-ppc64le:0.21.0',  # noqa
                   }
         context['ingress_image'] = images.get(context['arch'], images['amd64'])
-    if get_version('kubelet') < (1, 9):
-        context['daemonset_api_version'] = 'extensions/v1beta1'
-    else:
-        context['daemonset_api_version'] = 'apps/v1beta2'
-    manifest = addon_path.format('ingress-daemon-set.yaml')
-    render('ingress-daemon-set.yaml', manifest, context)
-    hookenv.log('Creating the ingress daemon set.')
+    manifest = addon_path.format('ingress-deployment.yaml')
+    context['num_replicas'] = config.get('ingress-num-replicas')
+    render('ingress-deployment.yaml', manifest, context)
+    hookenv.log('Creating the ingress deployment.')
     try:
         kubectl('apply', '-f', manifest)
     except CalledProcessError as e:
@@ -856,7 +854,7 @@ def launch_default_ingress_controller():
         return
 
     # Render the default http backend (404) replicationcontroller manifest
-    # needs to happen after ingress-daemon-set since that sets up the namespace
+    # needs to happen after ingress-deployment since that sets up the namespace
     manifest = addon_path.format('default-http-backend.yaml')
     render('default-http-backend.yaml', manifest, context)
     hookenv.log('Creating the default http backend.')

--- a/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
@@ -1,19 +1,27 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
-  name: default-http-backend
+  name: default-http-backend-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+  namespace: ingress-nginx-{{ juju_application }}
 spec:
   replicas: 1
   selector:
-    app: default-http-backend
+    matchLabels:
+      app.kubernetes.io/name: default-http-backend-{{ juju_application }}
+      app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
   template:
     metadata:
       labels:
-        app: default-http-backend
+        app.kubernetes.io/name: default-http-backend-{{ juju_application }}
+        app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     spec:
       terminationGracePeriodSeconds: 60
       containers:
-      - name: default-http-backend
+      - name: default-http-backend-{{ juju_application }}
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
@@ -26,19 +34,28 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 5
         ports:
-        - containerPort: 8080
+          - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: default-http-backend
-#  namespace: kube-system
+  name: default-http-backend-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
   labels:
-    k8s-app: default-http-backend
+    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 spec:
   ports:
   - port: 80
-    protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
-    app: default-http-backend
+    app.kubernetes.io/name: default-http-backend-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-daemon-set.yaml
@@ -1,12 +1,58 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx-{{ juju_application }}
+  labels:
+    cdk-{{ juju_application }}-ingress: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nginx-ingress-{{ juju_application }}-serviceaccount
+  name: nginx-ingress-serviceaccount-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: nginx-ingress-{{ juju_application }}-clusterrole
+  name: nginx-ingress-clusterrole-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -58,7 +104,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: nginx-ingress-{{ juju_application }}-role
+  name: nginx-ingress-role-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 rules:
   - apiGroups:
       - ""
@@ -94,61 +144,72 @@ rules:
       - endpoints
     verbs:
       - get
-      - create
-      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: nginx-ingress-role-nisa-{{ juju_application }}-binding
+  name: nginx-ingress-role-nisa-binding-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nginx-ingress-{{ juju_application }}-role
+  name: nginx-ingress-role-{{ juju_application }}
 subjects:
   - kind: ServiceAccount
-    name: nginx-ingress-{{ juju_application }}-serviceaccount
+    name: nginx-ingress-serviceaccount-{{ juju_application }}
+    namespace: ingress-nginx-{{ juju_application }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: nginx-ingress-clusterrole-nisa-{{ juju_application }}-binding
+  name: nginx-ingress-clusterrole-nisa-binding-{{ juju_application }}
+  labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nginx-ingress-{{ juju_application }}-clusterrole
+  name: nginx-ingress-clusterrole-{{ juju_application }}
 subjects:
   - kind: ServiceAccount
-    name: nginx-ingress-{{ juju_application }}-serviceaccount
-    namespace: default
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: nginx-load-balancer-{{ juju_application }}-conf
+    name: nginx-ingress-serviceaccount-{{ juju_application }}
+    namespace: ingress-nginx-{{ juju_application }}
 ---
 apiVersion: {{ daemonset_api_version }}
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-{{ juju_application }}-controller
+  name: nginx-ingress-controller-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
   labels:
+    app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+    app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     juju-application: nginx-ingress-{{ juju_application }}
+    cdk-{{ juju_application }}-ingress: "true"
 spec:
   selector:
     matchLabels:
-      name: nginx-ingress-{{ juju_application }}
+      app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+      app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
   template:
     metadata:
       labels:
-        name: nginx-ingress-{{ juju_application }}
+        app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
+        app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
     spec:
+      serviceAccountName: nginx-ingress-serviceaccount-{{ juju_application }}
       nodeSelector:
         juju-application: {{ juju_application }}
       terminationGracePeriodSeconds: 60
       # hostPort doesn't work with CNI, so we have to use hostNetwork instead
       # see https://github.com/kubernetes/kubernetes/issues/23920
       hostNetwork: true
-      serviceAccountName: nginx-ingress-{{ juju_application }}-serviceaccount
       containers:
       - image: {{ ingress_image }}
         name: nginx-ingress-{{ juju_application }}
@@ -159,6 +220,14 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
+          # www-data -> 33
+          runAsUser: 33
         # use downward API
         env:
           - name: POD_NAME
@@ -170,10 +239,35 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         ports:
-        - containerPort: 80
-        - containerPort: 443
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
         args:
         - /nginx-ingress-controller
-        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend-{{ juju_application }}
+        - --configmap=$(POD_NAMESPACE)/nginx-configuration
+        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+        - --annotations-prefix=nginx.ingress.kubernetes.io
         - --enable-ssl-chain-completion={{ ssl_chain_completion }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-deployment.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ingress-nginx-{{ juju_application }}
   labels:
     cdk-{{ juju_application }}-ingress: "true"
+
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -14,6 +15,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -24,6 +26,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -34,6 +37,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -44,6 +48,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -90,21 +95,23 @@ rules:
   - apiGroups:
       - ""
     resources:
-        - events
+      - events
     verbs:
-        - create
-        - patch
+      - create
+      - patch
   - apiGroups:
       - "extensions"
     resources:
       - ingresses/status
     verbs:
       - update
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: nginx-ingress-role-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
   labels:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
@@ -144,11 +151,13 @@ rules:
       - endpoints
     verbs:
       - get
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding-{{ juju_application }}
+  namespace: ingress-nginx-{{ juju_application }}
   labels:
     app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
     app.kubernetes.io/part-of: ingress-nginx-{{ juju_application }}
@@ -161,6 +170,7 @@ subjects:
   - kind: ServiceAccount
     name: nginx-ingress-serviceaccount-{{ juju_application }}
     namespace: ingress-nginx-{{ juju_application }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -178,9 +188,10 @@ subjects:
   - kind: ServiceAccount
     name: nginx-ingress-serviceaccount-{{ juju_application }}
     namespace: ingress-nginx-{{ juju_application }}
+
 ---
-apiVersion: {{ daemonset_api_version }}
-kind: DaemonSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: nginx-ingress-controller-{{ juju_application }}
   namespace: ingress-nginx-{{ juju_application }}
@@ -190,6 +201,7 @@ metadata:
     juju-application: nginx-ingress-{{ juju_application }}
     cdk-{{ juju_application }}-ingress: "true"
 spec:
+  replicas: {{ num_replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: ingress-nginx-{{ juju_application }}
@@ -211,63 +223,56 @@ spec:
       # see https://github.com/kubernetes/kubernetes/issues/23920
       hostNetwork: true
       containers:
-      - image: {{ ingress_image }}
-        name: nginx-ingress-{{ juju_application }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-        securityContext:
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - NET_BIND_SERVICE
-          # www-data -> 33
-          runAsUser: 33
-        # use downward API
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        ports:
-          - name: http
-            containerPort: 80
-          - name: https
-            containerPort: 443
-        args:
-        - /nginx-ingress-controller
-        - --default-backend-service=$(POD_NAMESPACE)/default-http-backend-{{ juju_application }}
-        - --configmap=$(POD_NAMESPACE)/nginx-configuration
-        - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
-        - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-        - --publish-service=$(POD_NAMESPACE)/ingress-nginx
-        - --annotations-prefix=nginx.ingress.kubernetes.io
-        - --enable-ssl-chain-completion={{ ssl_chain_completion }}
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /healthz
-            port: 10254
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
+        - name: nginx-ingress-controller{{ juju_application }}
+          image: {{ ingress_image }}
+          args:
+            - /nginx-ingress-controller
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+            - --enable-ssl-chain-completion={{ ssl_chain_completion }}
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 33
+            runAsUser: 33
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+            - name: https
+              containerPort: 443
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+---


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Updating nginx to match 1.13 deployment.

Note that this pushes nginx to its own namespace and changes from daemonset back to deployment. The deployment will make more sense to very large clusters and allow the operator to scale to match load.
Exposed number of replicas via config option on kubernetes-worker.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
arm64 support is broken in the latest images. I didn't change to an older version due to lack of testing ability. https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/689
**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. 
-->
```release-note
Updated nginx ingress images to match current upstream in kubernetes-worker charm.
```
