### PR TITLE
Remove CNI version from built resource filenames

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
+++ b/cluster/juju/layers/kubernetes-worker/build-cni-resources.sh
@@ -34,7 +34,7 @@ mkdir "$temp_dir"
       echo "Built $(date)" >> BUILD_INFO
       echo "build script commit: $build_script_commit" >> BUILD_INFO
       echo "cni-plugins commit: $(git show --oneline -q)" >> BUILD_INFO
-      tar -czf "$temp_dir/cni-$arch-$CNI_VERSION.tgz" .
+      tar -czf "$temp_dir/cni-$arch.tgz" .
     )
   done
 )


### PR DESCRIPTION
@battlemidget This makes the built CNI resource filenames more consistent. Consider merging this before you start on the automation for CNI. Cheers.