### PR TITLE
Extend the file descriptor limit for api server

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -603,8 +603,6 @@ def add_systemd_file_limit():
             f.write('[Service]\n')
             f.write('LimitNOFILE=65535')
 
-    check_call(['systemctl', 'daemon-reload'])
-
 
 def add_systemd_restart_always():
     template = 'templates/service-always-restart.systemd-latest.conf'
@@ -631,7 +629,6 @@ def add_systemd_restart_always():
             .format(service)
         os.makedirs(dest_dir, exist_ok=True)
         copyfile(template, '{}/always-restart.conf'.format(dest_dir))
-    check_call(['systemctl', 'daemon-reload'])
 
 
 @when('etcd.available', 'tls_client.server.certificate.saved',
@@ -662,6 +659,10 @@ def start_master():
 
     # increase file limit size
     add_systemd_file_limit()
+
+    # systemctl needs to pick up the changes
+    # from the last 2 commands.
+    check_call(['systemctl', 'daemon-reload'])
 
     # Add CLI options to all components
     configure_apiserver(etcd.get_connection_string())

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -594,6 +594,17 @@ def master_services_down():
             failing_services.append(service)
     return failing_services
 
+def add_systemd_file_limit():
+    directory = '/etc/systemd/system/snap.kube-apiserver.daemon.service.d'
+    file_name = 'file-limit.conf'
+    path = os.path.join(directory, file_name)
+    if not os.path.isfile(path):
+        with open(path, 'w') as f:
+            f.write('[Service]\n')
+            f.write('LimitNOFILE=65535')
+
+    check_call(['systemctl', 'daemon-reload'])
+
 
 def add_systemd_restart_always():
     template = 'templates/service-always-restart.systemd-latest.conf'
@@ -648,6 +659,9 @@ def start_master():
 
     # make all services restart all the time
     add_systemd_restart_always()
+
+    # increase file limit size
+    add_systemd_file_limit()
 
     # Add CLI options to all components
     configure_apiserver(etcd.get_connection_string())

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -596,6 +596,9 @@ def master_services_down():
 
 def add_systemd_file_limit():
     directory = '/etc/systemd/system/snap.kube-apiserver.daemon.service.d'
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+
     file_name = 'file-limit.conf'
     path = os.path.join(directory, file_name)
     if not os.path.isfile(path):


### PR DESCRIPTION
Fixing 
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/703
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/626