### PR TITLE
update cloud config on vsphere/openstack change

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -2004,8 +2004,8 @@ def _write_vsphere_snap_config(component):
         'server = {}'.format(vsphere.vsphere_ip),
         'datacenter = "{}"'.format(vsphere.datacenter),
         'default-datastore = "{}"'.format(vsphere.datastore),
-        'folder = "kubernetes"',
-        'resourcepool-path = ""',
+        'folder = "{}"'.format(vsphere.folder),
+        'resourcepool-path = "{}"'.format(vsphere.respool_path),
         '[Disk]',
         'scsicontrollertype = "pvscsi"',
     ]))

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1954,11 +1954,21 @@ def cloud_ready():
     remove_state('kubernetes-master.components.started')  # force restart
 
 
-@when('kubernetes-master.cloud.ready',
-      'endpoint.openstack.ready.changed')
-def update_openstack():
+@when('kubernetes-master.cloud.ready')
+@when_any('endpoint.openstack.ready.changed',
+          'endpoint.vsphere.ready.changed')
+def update_cloud_config():
+    '''Signal that cloud config has changed.
+
+    Some clouds (openstack, vsphere) support runtime config that needs to be
+    reflected in the k8s cloud config files when changed. Manage flags to
+    ensure this happens.
+    '''
     remove_state('kubernetes-master.cloud.ready')
-    remove_state('endpoint.openstack.ready.changed')
+    if is_state('endpoint.openstack.ready.changed'):
+        remove_state('endpoint.openstack.ready.changed')
+    if is_state('endpoint.vsphere.ready.changed'):
+        remove_state('endpoint.vsphere.ready.changed')
 
 
 def _cdk_addons_template_path():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one, leave it on its own line:

/kind bug

**What this PR does / why we need it**:
Support config-changed when openstack/vsphere integrators are related.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/695

**Special notes for your reviewer**:
Related to recent vsphere integrator change https://github.com/juju-solutions/charm-vsphere-integrator/pull/2, but doesn't depend on it.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE".
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
