### PR TITLE
Ceph pools to be created upon ceph-mon readiness

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -592,6 +592,7 @@ def set_final_status():
                 not ceph_admin.key():
             hookenv.status_set(
                 'waiting', 'Waiting for Ceph to provide a key.')
+            return
 
     hookenv.status_set('active', 'Kubernetes master running.')
 
@@ -1042,7 +1043,6 @@ def ceph_storage():
 
     # >=1.12 will use CSI.
     if get_version('kube-apiserver') >= (1, 12) and not ceph_admin.key():
-        hookenv.status_set('waiting', 'Waiting for Ceph to provide a key.')
         return  # Retry until Ceph gives us a key.
 
     ceph_context = {

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1030,7 +1030,7 @@ def ceph_storage():
 
     # >=1.12 will use CSI.
     if get_version('kube-apiserver') >= (1, 12) and not ceph_admin.key():
-        hookenv.status_set('blocked', 'Waiting for CSI to provide a key.')
+        hookenv.status_set('waiting', 'Waiting for CSI to provide a key.')
         return  # Retry until CSI gives us a key.
 
     ceph_context = {

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1084,8 +1084,10 @@ def ceph_storage():
             cmd = ['kubectl', 'apply', '-f', '/tmp/ceph-secret.yaml']
             check_call(cmd)
             os.remove('/tmp/ceph-secret.yaml')
+            set_state('kubernetes-master.ceph.pool.created')
         except:  # NOQA
-            # the enlistment in kubernetes failed, return and prepare for re-exec
+            # The enlistment in kubernetes failed, return and
+            # prepare for re-exec.
             return
 
     # When complete, set a state relating to configuration of the storage

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -581,6 +581,18 @@ def set_final_status():
         hookenv.status_set('active', msg)
         return
 
+    if is_state('ceph-storage.available') and \
+            is_state('ceph-storage.available') and \
+            is_state('kubernetes-master.privileged') and \
+            not is_state('kubernetes-master.ceph.configured'):
+
+        ceph_admin = endpoint_from_flag('ceph-storage.available')
+
+        if get_version('kube-apiserver') >= (1, 12) and \
+                not ceph_admin.key():
+            hookenv.status_set(
+                'waiting', 'Waiting for Ceph to provide a key.')
+
     hookenv.status_set('active', 'Kubernetes master running.')
 
 
@@ -1030,8 +1042,8 @@ def ceph_storage():
 
     # >=1.12 will use CSI.
     if get_version('kube-apiserver') >= (1, 12) and not ceph_admin.key():
-        hookenv.status_set('waiting', 'Waiting for CSI to provide a key.')
-        return  # Retry until CSI gives us a key.
+        hookenv.status_set('waiting', 'Waiting for Ceph to provide a key.')
+        return  # Retry until Ceph gives us a key.
 
     ceph_context = {
         'mon_hosts': ceph_admin.mon_hosts(),


### PR DESCRIPTION
Addressing https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/631

```
$ juju deploy canonical-kubernetes
$ juju deploy -n 3 ceph-mon
$ juju deploy -n 3 cs:ceph-osd --storage osd-devices=32G,2 --storage osd-journals=8G,1
$ juju add-relation ceph-mon ceph-osd
$ juju relate ceph-mon kubernetes-master

$ juju run --unit kubernetes-master/0 'ceph osd pool ls'
xfs-pool
ext4-pool
```

