### PR TITLE
Remove use of global / shared client certificate

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
@@ -9,7 +9,3 @@ includes:
 options:
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
-    server_certificate_path: '/srv/kubernetes/server.crt'
-    server_key_path: '/srv/kubernetes/server.key'
-    client_certificate_path: '/srv/kubernetes/client.crt'
-    client_key_path: '/srv/kubernetes/client.key'

--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -21,7 +21,7 @@ import subprocess
 from pathlib import Path
 
 from charms.reactive import when, when_any, when_not
-from charms.reactive import set_state, remove_state
+from charms.reactive import set_state, remove_state, is_state
 from charms.reactive import hook
 from charms.reactive import clear_flag, endpoint_from_flag
 from charmhelpers.core import hookenv
@@ -160,7 +160,8 @@ def install_load_balancer():
 
 @hook('upgrade-charm')
 def upgrade_charm():
-    request_server_certificates()
+    if is_state('certificates.available') and is_state('website.available'):
+        request_server_certificates()
     maybe_write_apilb_logrotate_config()
 
 

--- a/cluster/juju/layers/kubernetes-common/lib/charms/layer/kubernetes_common.py
+++ b/cluster/juju/layers/kubernetes-common/lib/charms/layer/kubernetes_common.py
@@ -36,6 +36,12 @@ db = unitdata.kv()
 kubeclientconfig_path = '/root/.kube/config'
 gcp_creds_env_key = 'GOOGLE_APPLICATION_CREDENTIALS'
 kubeproxyconfig_path = '/root/cdk/kubeproxyconfig'
+certs_dir = Path('/root/cdk')
+ca_crt_path = certs_dir / 'ca.crt'
+server_crt_path = certs_dir / 'server.crt'
+server_key_path = certs_dir / 'server.key'
+client_crt_path = certs_dir / 'client.crt'
+client_key_path = certs_dir / 'client.key'
 
 
 def get_version(bin_name):

--- a/cluster/juju/layers/kubernetes-e2e/layer.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/layer.yaml
@@ -8,5 +8,3 @@ includes:
 options:
   tls-client:
     ca_certificate_path: '/srv/kubernetes/ca.crt'
-    client_certificate_path: '/srv/kubernetes/client.crt'
-    client_key_path: '/srv/kubernetes/client.key'

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -30,10 +30,6 @@ options:
       - socat
   tls-client:
     ca_certificate_path: '/root/cdk/ca.crt'
-    server_certificate_path: '/root/cdk/server.crt'
-    server_key_path: '/root/cdk/server.key'
-    client_certificate_path: '/root/cdk/client.crt'
-    client_key_path: '/root/cdk/client.key'
   cdk-service-kicker:
     services:
       - snap.kube-apiserver.daemon

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -164,7 +164,6 @@ def check_for_upgrade_needed():
     migrate_from_pre_snaps()
     maybe_install_kube_proxy()
     update_certificates()
-    create_rbac_resources()
     add_rbac_roles()
     switch_auth_mode(forced=True)
     set_state('reconfigure.authentication.setup')
@@ -833,7 +832,7 @@ def send_data(tls, kube_api_endpoint):
                                    key_path=server_key_path)
 
     # Request a client cert for kubelet.
-    tls_client.request_server_cert('system:kube-apiserver',
+    tls_client.request_client_cert('system:kube-apiserver',
                                    crt_path=client_crt_path,
                                    key_path=client_key_path)
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1151,7 +1151,8 @@ def create_rbac_resources():
 
     # NB: when metrics and logs are retrieved by proxy, the 'user' is the
     # common name of the cert used to authenticate the proxied request.
-    # The CN for /root/cdk/client.crt is 'client'.
+    # The CN for /root/cdk/client.crt is 'system:kube-apiserver'
+    # (see the send_data handler, above).
     proxy_user = 'system:kube-apiserver'
     context = {'juju_application': hookenv.service_name(),
                'proxy_user': proxy_user}

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -795,9 +795,11 @@ def push_service_data(kube_api):
 
 
 @when('certificates.available', 'kube-api-endpoint.available')
-def send_data(tls, kube_api_endpoint):
+def send_data():
     '''Send the data that is required to create a server certificate for
     this server.'''
+    kube_api_endpoint = endpoint_from_flag('kube-api-endpoint.available')
+
     # Use the public ip of this unit as the Common Name for the certificate.
     common_name = hookenv.unit_public_ip()
 
@@ -839,11 +841,11 @@ def send_data(tls, kube_api_endpoint):
 
 @when('config.changed.extra_sans', 'certificates.available',
       'kube-api-endpoint.available')
-def update_certificates(tls, kube_api_endpoint):
+def update_certificates():
     # Using the config.changed.extra_sans flag to catch changes.
     # IP changes will take ~5 minutes or so to propagate, but
     # it will update.
-    send_data(tls, kube_api_endpoint)
+    send_data()
     clear_flag('config.changed.extra_sans')
 
 

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -33,10 +33,6 @@ options:
       - 'socat'
   tls-client:
     ca_certificate_path: '/root/cdk/ca.crt'
-    server_certificate_path: '/root/cdk/server.crt'
-    server_key_path: '/root/cdk/server.key'
-    client_certificate_path: '/root/cdk/client.crt'
-    client_key_path: '/root/cdk/client.key'
   cdk-service-kicker:
     services:
       - 'snap.kubelet.daemon'


### PR DESCRIPTION
Depends on https://github.com/juju-solutions/layer-tls-client/pull/15
Depends on https://github.com/juju-solutions/layer-easyrsa/pull/16

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The global client certificate was poor design because it was shared with multiple applications.  This fixes it so that the applications get their own client certificate.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
