### PR TITLE
Replicate snap refresh timer fix for master

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -435,38 +435,6 @@ def set_app_version():
     hookenv.application_version_set(version.split(b' v')[-1].rstrip())
 
 
-@when('kubernetes-master.snaps.installed')
-@when('snap.refresh.set')
-@when('leadership.is_leader')
-def process_snapd_timer():
-    ''' Set the snapd refresh timer on the leader so all cluster members
-    (present and future) will refresh near the same time. '''
-    # Get the current snapd refresh timer; we know layer-snap has set this
-    # when the 'snap.refresh.set' flag is present.
-    timer = snap.get(snapname='core', key='refresh.timer').decode('utf-8')
-
-    # The first time through, data_changed will be true. Subsequent calls
-    # should only update leader data if something changed.
-    if data_changed('master_snapd_refresh', timer):
-        hookenv.log('setting snapd_refresh timer to: {}'.format(timer))
-        leader_set({'snapd_refresh': timer})
-
-
-@when('kubernetes-master.snaps.installed')
-@when('snap.refresh.set')
-@when('leadership.changed.snapd_refresh')
-@when_not('leadership.is_leader')
-def set_snapd_timer():
-    ''' Set the snapd refresh.timer on non-leader cluster members. '''
-    # NB: This method should only be run when 'snap.refresh.set' is present.
-    # Layer-snap will always set a core refresh.timer, which may not be the
-    # same as our leader. Gating with 'snap.refresh.set' ensures layer-snap
-    # has finished and we are free to set our config to the leader's timer.
-    timer = leader_get('snapd_refresh')
-    hookenv.log('setting snapd_refresh timer to: {}'.format(timer))
-    snap.set_refresh_timer(timer)
-
-
 @hookenv.atexit
 def set_final_status():
     ''' Set the final status of the charm as we leave hook execution '''


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The fix in #212 should apply equally to both master and worker, so this
moves it to the base.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
