### PR TITLE
add shebang to docker-compose pre-install stub

### DIFF
--- a/cluster/juju/layers/kubernetes-master-worker-base/exec.d/docker-compose/charm-pre-install
+++ b/cluster/juju/layers/kubernetes-master-worker-base/exec.d/docker-compose/charm-pre-install
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 # This stubs out charm-pre-install coming from layer-docker as a workaround for 
 # offline installs until https://github.com/juju/charm-tools/issues/301 is fixed.


### PR DESCRIPTION
First reported in https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/625, if somehow this script gets marked executable, layer-basic will run it, and we'll get an OSError because of the lack of shebang.

Under normal circumstances, we'll never run this file because it's not executable, but it's possible an operator could have a umask that makes all files exe by default. Untarring a shrinkwrap tarball in this scenario would cause this to get a +x, and proceed to blow up at deploy time.

To be on the safe side, let's just add a shebang. This script doesn't do anything, so even if it is unintentionally executed, no harm done.