### PR TITLE
Adding configuration option for ceph CSI

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
+++ b/cluster/juju/layers/kubernetes-master/actions/create-rbd-pv
@@ -19,6 +19,7 @@ from charms.reactive import is_state
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import action_fail
+from charmhelpers.core.hookenv import config
 from subprocess import check_call
 from subprocess import check_output
 from subprocess import CalledProcessError
@@ -38,13 +39,13 @@ def main():
     this script thinks the environment is 'sane' enough to provision volumes.
     '''
 
+    using_csi = config().get('ceph-use-csi')
     # k8s >= 1.10 uses CSI and doesn't directly create persistent volumes
-    if get_version('kube-apiserver') >= (1, 10):
-       print('This action is deprecated in favor of CSI creation of persistent volumes')
-       print('in Kubernetes >= 1.10. Just create the PVC and a PV will be created')
-       print('for you.')
-       action_fail('Deprecated, just create PVC.')
-       return
+    if using_csi:
+        print('CSI is enabled. This action is not used with CSI. Volume')
+        print('creation occurs when a PVC is created.')
+        action_fail('Deprecated, just create PVC.')
+        return
 
     # validate relationship pre-reqs before additional steps can be taken
     if not validate_relation():

--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -246,3 +246,8 @@ options:
     description: |
       Path to Keystone certificate authority for securing communications to Keystone.
     default: ""
+  ceph-use-csi:
+    type: boolean
+    default: true
+    description: |
+      Enables the Container Storage Interface version of Ceph on clusters that support it.

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1103,7 +1103,6 @@ def ceph_storage():
             cmd = ['kubectl', 'apply', '-f', '/tmp/ceph-secret.yaml']
             check_call(cmd)
             os.remove('/tmp/ceph-secret.yaml')
-            set_state('kubernetes-master.ceph.pool.created')
         except:  # NOQA
             # The enlistment in kubernetes failed, return and
             # prepare for re-exec.


### PR DESCRIPTION
kind feature

**What this PR does / why we need it**:
Adds the config option ceph-use-csi on the kubernetes-master charm with the default value of true. If true, CSI is only actually used if api version is >=1.12

**Which issue(s) this PR fixes**:

This was brought up in an issue, but I can't find it now.
```release-note
Added ceph-use-csi to enable or disable CSI-based ceph.
```
