### PR TITLE
Fix wrong name in requestheader-allowed-names

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1518,7 +1518,7 @@ def configure_apiserver(etcd_connection_string):
     if kube_version > (1, 6) and \
        hookenv.config('enable-metrics'):
         api_opts['requestheader-client-ca-file'] = str(ca_crt_path)
-        api_opts['requestheader-allowed-names'] = 'client'
+        api_opts['requestheader-allowed-names'] = 'system:kube-apiserver'
         api_opts['requestheader-extra-headers-prefix'] = 'X-Remote-Extra-'
         api_opts['requestheader-group-headers'] = 'X-Remote-Group'
         api_opts['requestheader-username-headers'] = 'X-Remote-User'


### PR DESCRIPTION
This fixes the following error spam from metrics-server:
```
W0220 18:46:36.386183       1 x509.go:172] x509: subject with cn=system:kube-apiserver is not in the allowed list: [client]
W0220 18:46:36.494335       1 x509.go:172] x509: subject with cn=system:kube-apiserver is not in the allowed list: [client]
```

The CN was changed from `client` to `system:kube-apiserver` here: https://github.com/juju-solutions/kubernetes/pull/207