### PR TITLE
Add block storage options for OpenStack

### DIFF
--- a/cluster/juju/layers/kubernetes-common/lib/charms/layer/kubernetes_common.py
+++ b/cluster/juju/layers/kubernetes-common/lib/charms/layer/kubernetes_common.py
@@ -460,6 +460,19 @@ def write_openstack_snap_config(component):
     if openstack.manage_security_groups:
         lines.append('manage-security-groups = {}'.format(
             openstack.manage_security_groups))
+    if any([openstack.bs_version,
+            openstack.trust_device_path,
+            openstack.ignore_volume_az]):
+        lines.append('')
+        lines.append('[BlockStorage]')
+    if openstack.bs_version is not None:
+        lines.append('bs-version = {}'.format(openstack.bs_version))
+    if openstack.trust_device_path is not None:
+        lines.append('trust-device-path = {}'.format(
+            openstack.trust_device_path))
+    if openstack.ignore_volume_az is not None:
+        lines.append('ignore-volume-az = {}'.format(
+            openstack.ignore_volume_az))
 
     comp_cloud_config_path = cloud_config_path(component)
     comp_cloud_config_path.write_text(''.join('{}\n'.format(l) for l in lines))


### PR DESCRIPTION
Depends on https://github.com/juju-solutions/interface-openstack-integration/pull/10
Depends on https://github.com/juju-solutions/charm-openstack-integrator/pull/15

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Handles block storage config options proxied from OpenStack Integration charm.

**Which issue(s) this PR fixes**:

Addresses https://bugs.launchpad.net/charm-openstack-integrator/+bug/1809349

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
