### PR TITLE
add new get-kubeconfig action to kubernetes-master

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions.yaml
+++ b/cluster/juju/layers/kubernetes-master/actions.yaml
@@ -48,3 +48,5 @@ namespace-delete:
     - name
 upgrade:
     description: Upgrade the kubernetes snaps
+get-kubeconfig:
+  description: Retrieve Kubernetes cluster config, including credentials

--- a/cluster/juju/layers/kubernetes-master/actions/get-kubeconfig
+++ b/cluster/juju/layers/kubernetes-master/actions/get-kubeconfig
@@ -1,0 +1,42 @@
+#!/usr/local/sbin/charm-env python3
+import os
+import json
+from charmhelpers.core.hookenv import (
+    action_get,
+    action_set,
+    action_fail,
+    action_name
+)
+from charmhelpers.core.templating import render
+from subprocess import check_output
+
+
+def _kubectl(args):
+    """
+    Executes kubectl with args as arguments
+    """
+    snap_bin = os.path.join(os.sep, "snap", "bin")
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join([snap_bin, env["PATH"]])
+    cmd = ["kubectl", "--kubeconfig=/home/ubuntu/config"]
+    cmd.extend(args)
+    return check_output(cmd, env=env)
+
+
+def get_kubeconfig():
+    """
+    Read the kubeconfig on the master and return it as JSON
+    """
+    try:
+        result = _kubectl(["config", "view", "-o", "json", "--raw"])
+        # JSON format verification
+        kubeconfig = json.dumps(json.loads(result))
+        action_set({"kubeconfig": kubeconfig})
+    except JSONDecodeError as e:
+        action_fail("Failed to parse kubeconfig: {}".format(str(e)))
+    except Exception as e:
+        action_fail("Failed to retrieve kubeconfig: {}".format(str(e)))
+
+action = action_name()
+if action == "get-kubeconfig":
+    get_kubeconfig()


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Once the k8s cluster is completed the config with login credentials is stored at `/home/ubuntu/config`. With this juju action we enable users to pull out credentials to connect to the cluster. 

Alternatively, we could use `juju scp --proxy=true` but python libjuju (https://pythonlibjuju.readthedocs.io/en/latest/_modules/juju/machine.html#Machine.scp_from) doesn't support *proxy* yet as we require it.


**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Usecase has been discussed with @tvansteenburgh 

**Does this PR introduce a user-facing change?**:
```release-note
Add new get-kubeconfig action to kubernetes-master
```
