### PR TITLE
Adding dashboard auth option

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -246,3 +246,10 @@ options:
     description: |
       Path to Keystone certificate authority for securing communications to Keystone.
     default: ""
+  dashboard-auth:
+    type: string
+    description: |
+      Method of authentication for the Kubernetes dashboard. Options are auto, basic,
+      and token. If auto, basic used unless keystone is related to kubernetes-master in
+      which case token is used.
+    default: "auto"

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -885,6 +885,7 @@ def configure_cdk_addons():
     dnsEnabled = str(hookenv.config('enable-kube-dns')).lower()
     metricsEnabled = str(hookenv.config('enable-metrics')).lower()
     default_storage = ''
+    dashboard_auth = str(hookenv.config('dashboard-auth')).lower()
     ceph = {}
     if (is_state('kubernetes-master.ceph.configured') and
             get_version('kube-apiserver') >= (1, 12)):
@@ -912,6 +913,12 @@ def configure_cdk_addons():
     else:
         keystoneEnabled = "false"
 
+    if dashboard_auth == 'auto':
+        if ks:
+            dashboard_auth = 'token'
+        else:
+            dashboard_auth = 'basic'
+
     args = [
         'arch=' + arch(),
         'dns-ip=' + get_deprecated_dns_ip(),
@@ -930,7 +937,8 @@ def configure_cdk_addons():
         'keystone-cert-file=' + keystone.get('cert', ''),
         'keystone-key-file=' + keystone.get('key', ''),
         'keystone-server-url=' + keystone.get('url', ''),
-        'keystone-server-ca=' + keystone.get('keystone-ca', '')
+        'keystone-server-ca=' + keystone.get('keystone-ca', ''),
+        'dashboard-auth=' + dashboard_auth
     ]
     check_call(['snap', 'set', 'cdk-addons'] + args)
     if not addons_ready():


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Adds a configuration option dashboard-auth to kubernetes-master charm for selecting the dashboard auth method.

```release-note
Added dashboard-auth configuration option. Defaults to auto and will select basic unless keystone is related, when it then selects token authentication. Can also be set to either basic or token to force the authentication mode.
```
