### PR TITLE
Fixing an issue with easyrsa and hacluster

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -83,7 +83,7 @@ def request_server_certificates():
         dns_record = hookenv.config('ha-cluster-dns')
         if vips:
             sans.extend(vips)
-        else:
+        elif dns_record:
             sans.append(dns_record)
 
     # maybe they have extra names they want as SANs
@@ -208,8 +208,10 @@ def provide_application_details():
         dns_record = hookenv.config('ha-cluster-dns')
         if vips:
             website.configure(hookenv.config('port'), vips, vips)
-        else:
+        elif dns_record:
             website.configure(hookenv.config('port'), dns_record, dns_record)
+        else:
+            website.configure(port=hookenv.config('port'))
     else:
         website.configure(port=hookenv.config('port'))
 
@@ -229,8 +231,10 @@ def provide_loadbalancing():
         dns_record = hookenv.config('ha-cluster-dns')
         if vips:
             address = vips
-        else:
+        elif dns_record:
             address = dns_record
+        else:
+            address = hookenv.unit_get('public-address')
     else:
         address = hookenv.unit_get('public-address')
     loadbalancer.set_address_port(address, hookenv.config('port'))

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -784,8 +784,10 @@ def push_service_data():
         if vips:
             # each worker unit will pick one based on unit number
             kube_api.configure(6443, vips, vips)
-        else:
+        elif dns_record:
             kube_api.configure(6443, dns_record, dns_record)
+        else:
+            kube_api.configure(6443)
     else:
         kube_api.configure(6443)
 
@@ -828,7 +830,7 @@ def send_data():
         dns_record = hookenv.config('ha-cluster-dns')
         if vips:
             sans.extend(vips)
-        else:
+        elif dns_record:
             sans.append(dns_record)
     elif loadbalancer:
         # Get the list of loadbalancers from the relation object.
@@ -2218,7 +2220,7 @@ def get_hacluster_ip_or_hostname():
         if vips:
             # each unit will pick one based on unit number
             return vips[get_unit_number() % len(vips)]
-        else:
+        elif dns_record:
             return dns_record
 
     return None


### PR DESCRIPTION
easyrsa would puke if you had no configured virtual IP or dns for hacluster, but had hacluster related. It blew up because we added an extra sans of an empty string, which resulted in a call to create a cert with an empty name, which easyrsa didn't like of course. This fixes that by checking for no config options at all set.

/kind bug

```release-note
NONE
```
