### PR TITLE
Allow setting the ip for cluster control plane

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -263,3 +263,12 @@ options:
       "basic", and "token". If set to "auto", basic auth is used unless Keystone is 
       related to kubernetes-master, in which case token auth is used.
     default: "auto"
+  loadbalancer-ips:
+    type: string
+    description: |
+      Space seperated list of IP addresses of loadbalancers in front of control plane.
+      These can be either virtual IP addresses that are floated in front of the control
+      plane or the IP of a loadbalancer such as an F5. The workers will alternate IP
+      addresses from this list to distribute load. If you have 2 IPs and 4 workers,
+      each IP will be used by 2 workers.
+    default: ""

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -819,21 +819,27 @@ def send_data():
         'kubernetes.default.svc.{0}'.format(domain)
     ]
 
-    loadbalancer = endpoint_from_flag('loadbalancer.available')
-    # we don't use get_hacluster_ip_or_hostname only here because
-    # we want the cert to be valid for all the vips
-    hacluster = endpoint_from_flag('ha.connected')
-    if hacluster:
-        vips = hookenv.config('ha-cluster-vip').split()
-        dns_record = hookenv.config('ha-cluster-dns')
-        if vips:
-            sans.extend(vips)
-        else:
-            sans.append(dns_record)
-    elif loadbalancer:
-        # Get the list of loadbalancers from the relation object.
-        hosts = loadbalancer.get_addresses_ports()
-        sans.extend([host.get('public-address') for host in hosts])
+    # if the user gave us IPs for the load balancer, assume they know
+    # what they are talking about and use that instead of our information.
+    forced_lb_ips = hookenv.config('loadbalancer-ips').split()
+    if forced_lb_ips:
+        sans.extend(forced_lb_ips)
+    else:
+        loadbalancer = endpoint_from_flag('loadbalancer.available')
+        # we don't use get_hacluster_ip_or_hostname only here because
+        # we want the cert to be valid for all the vips
+        hacluster = endpoint_from_flag('ha.connected')
+        if hacluster:
+            vips = hookenv.config('ha-cluster-vip').split()
+            dns_record = hookenv.config('ha-cluster-dns')
+            if vips:
+                sans.extend(vips)
+            else:
+                sans.append(dns_record)
+        elif loadbalancer:
+            # Get the list of loadbalancers from the relation object.
+            hosts = loadbalancer.get_addresses_ports()
+            sans.extend([host.get('public-address') for host in hosts])
 
     # maybe they have extra names they want as SANs
     extra_sans = hookenv.config('extra_sans')
@@ -988,12 +994,18 @@ def loadbalancer_kubeconfig():
     hosts = loadbalancer.get_addresses_ports()
     # if there is a hacluster relation, use that vip/dns for the kubeconfig
     hacluster_vip = get_hacluster_ip_or_hostname()
-    if hacluster_vip:
-        address = hacluster_vip
+    # if the user gave us IPs for the load balancer, assume they know
+    # what they are talking about and use that instead of our information.
+    forced_lb_ips = hookenv.config('loadbalancer-ips').split()
+    if forced_lb_ips:
+        address = forced_lb_ips[get_unit_number() % len(forced_lb_ips)]
     else:
-        # Get the public address of the first loadbalancer so
-        # users can access the cluster.
-        address = hosts[0].get('public-address')
+        if hacluster_vip:
+            address = hacluster_vip
+        else:
+            # Get the public address of the first loadbalancer so
+            # users can access the cluster.
+            address = hosts[0].get('public-address')
 
     # Get the port of the loadbalancer so users can access the cluster.
     port = hosts[0].get('port')
@@ -1006,11 +1018,17 @@ def loadbalancer_kubeconfig():
 @when_not('loadbalancer.available')
 def create_self_config():
     '''Create a kubernetes configuration for the master unit.'''
-    hacluster_vip = get_hacluster_ip_or_hostname()
-    if hacluster_vip:
-        address = hacluster_vip
+    # if the user gave us IPs for the load balancer, assume they know
+    # what they are talking about and use that instead of our information.
+    forced_lb_ips = hookenv.config('loadbalancer-ips').split()
+    if forced_lb_ips:
+        address = forced_lb_ips[get_unit_number() % len(forced_lb_ips)]
     else:
-        address = hookenv.unit_get('public-address')
+        hacluster_vip = get_hacluster_ip_or_hostname()
+        if hacluster_vip:
+            address = hacluster_vip
+        else:
+            address = hookenv.unit_get('public-address')
     server = 'https://{0}:{1}'.format(address, 6443)
     build_kubeconfig(server)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This allows the user to specify the control plane IP. This is very useful if they are bringing their own load balancer. We've had this come up in https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/629.
```release-note
Added loadbalancer-ips config option to specify the IP address to use to reach the control plane from inside the cluster.
```
