### PR TITLE
fix defaultbackend-s390x image

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -792,7 +792,7 @@ def render_and_launch_ingress():
        context['defaultbackend_image'] == "auto"):
         if context['arch'] == 's390x':
             context['defaultbackend_image'] = \
-                "k8s.gcr.io/defaultbackend-s390x:1.5"
+                "k8s.gcr.io/defaultbackend-s390x:1.4"
         elif context['arch'] == 'arm64':
             context['defaultbackend_image'] = \
                 "k8s.gcr.io/defaultbackend-arm64:1.5"


### PR DESCRIPTION
1.5 doesn't exist for s390x, let's go back to 1.4:

https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/defaultbackend-s390x?gcrImageListsize=30

Confirmed much pod success on s3lp3:
```
$ kubectl describe pod/default-http-backend-kubernetes-worker-55b4bf4d47-vdvmk -n ingress-nginx-kubernetes-worker
Name:           default-http-backend-kubernetes-worker-55b4bf4d47-vdvmk
Namespace:      ingress-nginx-kubernetes-worker
...
Status:         Running
...
    Image:          k8s.gcr.io/defaultbackend-s390x:1.4
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
